### PR TITLE
Disable Movement at End of Level

### DIFF
--- a/Assets/Animations/Characters/Stickman/Stickman Spawn 1.anim
+++ b/Assets/Animations/Characters/Stickman/Stickman Spawn 1.anim
@@ -164,5 +164,5 @@ AnimationClip:
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
-    intParameter: 0
+    intParameter: 1
     messageOptions: 0

--- a/Assets/Scenes/Levels/Claire Part 1.unity
+++ b/Assets/Scenes/Levels/Claire Part 1.unity
@@ -4904,11 +4904,11 @@ PrefabInstance:
       objectReference: {fileID: 1265930444}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 75.38
+      value: 3.5367103
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 21.19
+      value: 20.900488
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4964,11 +4964,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 242199389850525460, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 26.20633
+      value: -48.80367
       objectReference: {fileID: 0}
     - target: {fileID: 242199389850525460, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 16.627573
+      value: 16.337572
       objectReference: {fileID: 0}
     - target: {fileID: 242199389850525460, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5017,11 +5017,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1450883229827684623, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 75.38
+      value: 0.37
       objectReference: {fileID: 0}
     - target: {fileID: 1450883229827684623, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 20.69
+      value: 20.4
       objectReference: {fileID: 0}
     - target: {fileID: 1450883229827684623, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/LevelEndTrigger.cs
+++ b/Assets/Scripts/LevelEndTrigger.cs
@@ -16,6 +16,7 @@ public class LevelEndTrigger : MonoBehaviour
     public void LoadNextScene() {
         if(!triggered) {
             FindObjectOfType<SceneLoader>().LoadNextScene();
+            FindObjectOfType<PlayerMovement>().setCanMove(0);
             triggered = true;
         }
     }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -213,7 +213,7 @@ public class PlayerMovement : MonoBehaviour
 
         isDead = false;
     }
-    public void setCanMove() {
-        rb2d.simulated = true;
+    public void setCanMove(int isOne) {
+        rb2d.simulated = (isOne == 1);
     }
 }


### PR DESCRIPTION
- LevelEndTrigger will now call setCanMove() on Stickman, setting his Rb2d to be unable to move
- Changed logic of setCanMove, have to use int instead of bool because it gets called by an animation event
- Moved stickman back in ClaireP1