### PR TITLE
Disable pause during transition 2

### DIFF
--- a/Assets/Scripts/Scene Loading/SceneLoader.cs
+++ b/Assets/Scripts/Scene Loading/SceneLoader.cs
@@ -15,9 +15,11 @@ public class SceneLoader : MonoBehaviour
     // State variables
     bool isLoading = false;
     private AudioSource audioSource;
+    MenuManager menuManager;
 
     void Start() {
         audioSource = GetComponent<AudioSource>();
+        menuManager = FindObjectOfType<MenuManager>();
     }
     // Load the first level
     public void StartGame()
@@ -55,7 +57,7 @@ public class SceneLoader : MonoBehaviour
     // Loads a scene
     public void LoadScene(int index)
     {
-        StartCoroutine(LoadSceneRoutine(index));
+        StartCoroutine(LoadSceneAndPause(index));
     }
 
     // A coroutine that loads a given scene
@@ -91,6 +93,14 @@ public class SceneLoader : MonoBehaviour
         yield return transition.FadeIn();
 
         isLoading = false;
+    }
+    // This is a coroutine I made so I'd be able to check when a level has finished loading.
+    // Disable the pause menu when we begin loading a new level, yield until the level is loaded, then enable the pause menu for use.
+    IEnumerator LoadSceneAndPause(int index) {
+        menuManager.enablePause(false);
+        yield return StartCoroutine(LoadSceneRoutine(index));
+        menuManager = FindObjectOfType<MenuManager>();
+        menuManager.enablePause(true);  
     }
 
     // Returns the current scene index

--- a/Assets/Scripts/Scene Loading/SceneLoader.cs
+++ b/Assets/Scripts/Scene Loading/SceneLoader.cs
@@ -57,7 +57,7 @@ public class SceneLoader : MonoBehaviour
     // Loads a scene
     public void LoadScene(int index)
     {
-        StartCoroutine(LoadSceneAndPause(index));
+        StartCoroutine(LoadSceneRoutine(index));
     }
 
     // A coroutine that loads a given scene
@@ -67,7 +67,7 @@ public class SceneLoader : MonoBehaviour
         if (isLoading)
             yield break;
         isLoading = true;
-
+        menuManager.enablePause(false);
         // Set the transition color based on the level index.
         bool loadingToMenu = index == config.mainMenuBuildIndex;
         Color transitionColor = loadingToMenu
@@ -93,14 +93,8 @@ public class SceneLoader : MonoBehaviour
         yield return transition.FadeIn();
 
         isLoading = false;
-    }
-    // This is a coroutine I made so I'd be able to check when a level has finished loading.
-    // Disable the pause menu when we begin loading a new level, yield until the level is loaded, then enable the pause menu for use.
-    IEnumerator LoadSceneAndPause(int index) {
-        menuManager.enablePause(false);
-        yield return StartCoroutine(LoadSceneRoutine(index));
         menuManager = FindObjectOfType<MenuManager>();
-        menuManager.enablePause(true);  
+        menuManager.enablePause(true);
     }
 
     // Returns the current scene index

--- a/Assets/Scripts/UI/MenuManager.cs
+++ b/Assets/Scripts/UI/MenuManager.cs
@@ -20,16 +20,10 @@ public class MenuManager : MonoBehaviour
         if (GetCurrentSceneIndex() == config.mainMenuBuildIndex) {
             mainMenu.SetActive(true);
         }
-        // If not in the Main Menu Scene menu, enable the Pause Menu.
-        // This does not immediately make it visible though. It just allows 
-        // Pause Menu to listen to the Esc key and manage the UI visibility itself.
-        else {
-            enablePause(true);
-        }
-        
         // Disable all other canvases
         enableSettings(false);
         enableLevels(false);
+        enablePause(false);
     }
 
     // Public functions for OnClick() to call
@@ -40,7 +34,7 @@ public class MenuManager : MonoBehaviour
             Debug.Log("Tried to enable settings menu but it's undefined");
     }
     public void enablePause(bool enable) {
-        if (pauseMenu) 
+        if (pauseMenu && !(GetCurrentSceneIndex() == config.mainMenuBuildIndex)) 
             pauseMenu.SetActive(enable);
         else 
             Debug.Log("Tried to enable pause menu but it's undefined");


### PR DESCRIPTION
Pause Menu will now not be accessible until a level has completed loading in.

New Coroutine in Scene Loader that waits for scene to be loaded
Menu Manager won't enable Pause on default now; Pause enabling is handle by scene loader now.