### PR TITLE
update scaling and aspect ratio fitting of UI and viewport

### DIFF
--- a/Assets/Prefabs/Credits/Credits.prefab
+++ b/Assets/Prefabs/Credits/Credits.prefab
@@ -1,5 +1,94 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1260246775971977355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4109029953145918380}
+  - component: {fileID: 3838242842222493787}
+  - component: {fileID: 6610071928906131572}
+  - component: {fileID: 8269447382837235168}
+  m_Layer: 5
+  m_Name: Aspect Ratio Fitter Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4109029953145918380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260246775971977355}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8175647883033594472}
+  - {fileID: 8189452181433759162}
+  m_Father: {fileID: 7339592049469199570}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &3838242842222493787
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260246775971977355}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6610071928906131572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260246775971977355}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
+--- !u!114 &8269447382837235168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260246775971977355}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &2319971541946631149
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,12 +118,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 20.009}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 526, y: -4111}
+  m_AnchoredPosition: {x: 526, y: -4688}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1122413781303477911
@@ -104,12 +193,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 16.257}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -535, y: -8147}
+  m_AnchoredPosition: {x: -535, y: -8724}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1996438287442452737
@@ -179,12 +268,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -10.872}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -627, y: -7472}
+  m_AnchoredPosition: {x: -627, y: -8049}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7565013383302091105
@@ -270,8 +359,8 @@ RectTransform:
   m_Father: {fileID: 8189452181433759162}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
@@ -398,6 +487,115 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3889410799795508025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7339592049469199570}
+  - component: {fileID: 5806404914603440010}
+  - component: {fileID: 3191456169341468939}
+  - component: {fileID: 2749919613008846038}
+  - component: {fileID: 839488681121696154}
+  m_Layer: 5
+  m_Name: Credits Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7339592049469199570
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3889410799795508025}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 4109029953145918380}
+  m_Father: {fileID: 8175647882358297136}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &5806404914603440010
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3889410799795508025}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &3191456169341468939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3889410799795508025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1620, y: 1080}
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &2749919613008846038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3889410799795508025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!222 &839488681121696154
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3889410799795508025}
+  m_CullTransparentMesh: 1
 --- !u!1 &3948833098752775081
 GameObject:
   m_ObjectHideFlags: 0
@@ -427,12 +625,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 16.257}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 563, y: -6292}
+  m_AnchoredPosition: {x: 563, y: -6869}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5201434, y: 0.56907856}
 --- !u!222 &3419407276215716113
@@ -481,7 +679,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5776221039866070680}
+  - component: {fileID: 19508667166656458}
+  - component: {fileID: 5909968967763219756}
   m_Layer: 0
   m_Name: Decoration
   m_TagString: Untagged
@@ -489,15 +688,15 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5776221039866070680
-Transform:
+--- !u!224 &19508667166656458
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4605860606073886383}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -540, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1738706807284015179}
@@ -513,6 +712,32 @@ Transform:
   m_Father: {fileID: 8189452181433759162}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!223 &5909968967763219756
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4605860606073886383}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &5503816935480803700
 GameObject:
   m_ObjectHideFlags: 0
@@ -542,12 +767,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -17.173}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 632, y: -2408}
+  m_AnchoredPosition: {x: 632, y: -2985.0002}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6604063178587583769
@@ -617,12 +842,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 20.115}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -542, y: -1170}
+  m_AnchoredPosition: {x: -542, y: -1747.0002}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4231886547829529231
@@ -692,12 +917,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 17.21}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -540, y: -5304}
+  m_AnchoredPosition: {x: -540, y: -5881}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9084204837664159690
@@ -767,12 +992,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -9.882}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -506, y: -3551}
+  m_AnchoredPosition: {x: -506, y: -4128}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5565453557959761626
@@ -844,12 +1069,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 231484342822953202}
-  - {fileID: 5776221039866070680}
-  m_Father: {fileID: 8175647882358297136}
+  - {fileID: 19508667166656458}
+  m_Father: {fileID: 4109029953145918380}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
@@ -903,9 +1128,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8175647882358297136}
-  - component: {fileID: 8175647882358297137}
-  - component: {fileID: 8175647882358297138}
-  - component: {fileID: 8175647882358297139}
   - component: {fileID: 4303343884101709988}
   - component: {fileID: 7759094549475506234}
   m_Layer: 5
@@ -924,79 +1146,17 @@ RectTransform:
   m_GameObject: {fileID: 8175647882358297148}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 8175647883033594472}
-  - {fileID: 8189452181433759162}
+  - {fileID: 7339592049469199570}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!223 &8175647882358297137
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8175647882358297148}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &8175647882358297138
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8175647882358297148}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &8175647882358297139
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8175647882358297148}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
+  m_AnchoredPosition: {x: 301.25, y: 342.25}
+  m_SizeDelta: {x: 602.5, y: 684.5}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!320 &4303343884101709988
 PlayableDirector:
   m_ObjectHideFlags: 0
@@ -1070,7 +1230,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 8175647882358297136}
+  m_Father: {fileID: 4109029953145918380}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -1164,12 +1324,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 18.032}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 519, y: -2017}
+  m_AnchoredPosition: {x: 519, y: -2594.0002}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1765650410483303069
@@ -1239,12 +1399,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -135.0487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5776221039866070680}
+  m_Father: {fileID: 19508667166656458}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -18.609}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 550, y: -8877}
+  m_AnchoredPosition: {x: 550, y: -9454}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3219905800620216776
@@ -1703,7 +1863,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802162, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -116.869995
+      value: -116.87012
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802173, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_IsActive
@@ -2878,7 +3038,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802162, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -216.48999
+      value: -216.49023
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802173, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_IsActive
@@ -3882,7 +4042,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802162, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -116.869995
+      value: -116.87012
       objectReference: {fileID: 0}
     - target: {fileID: 8957195410269802173, guid: 46fa8a74a1c7d41419349d62038eabb3, type: 3}
       propertyPath: m_IsActive

--- a/Assets/Prefabs/Gameplay Systems/Dialogue System.prefab
+++ b/Assets/Prefabs/Gameplay Systems/Dialogue System.prefab
@@ -10,10 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 8723482651956380621}
   - component: {fileID: 5714228004283927735}
-  - component: {fileID: 3432602056942258913}
-  - component: {fileID: 2663735953781368772}
+  - component: {fileID: 6261874717795993588}
   m_Layer: 0
-  m_Name: Dialogue Canvas
+  m_Name: Aspect Ratio Fitter Canvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26,23 +25,22 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 170163530068015359}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6736147193481750046}
   - {fileID: 4640808624471028755}
   - {fileID: 6178720148569494608}
   - {fileID: 5260671945467832203}
-  - {fileID: 3460942540350147095}
-  m_Father: {fileID: 6344986284834697497}
+  m_Father: {fileID: 5017743644008061127}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &5714228004283927735
 Canvas:
   m_ObjectHideFlags: 0
@@ -64,7 +62,7 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 100
   m_TargetDisplay: 0
---- !u!114 &3432602056942258913
+--- !u!114 &6261874717795993588
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -73,37 +71,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 170163530068015359}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 1
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!114 &2663735953781368772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170163530068015359}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
 --- !u!1 &937505186594551469
 GameObject:
   m_ObjectHideFlags: 0
@@ -132,7 +104,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 8723482651956380621}
+  - {fileID: 5017743644008061127}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -300,13 +272,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 8723482651956380621}
-  m_RootOrder: 4
+  m_Father: {fileID: 5017743644008061127}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -288.26, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3205151214642331408
 CanvasRenderer:
@@ -682,7 +654,6 @@ GameObject:
   - component: {fileID: 8672991090251838589}
   - component: {fileID: 665641430772605634}
   - component: {fileID: 1058830959415770078}
-  - component: {fileID: 4356269193235019258}
   m_Layer: 5
   m_Name: IRL Cutscene Image
   m_TagString: Untagged
@@ -766,20 +737,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!114 &4356269193235019258
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5603932475415237835}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 2
-  m_AspectRatio: 1.5
 --- !u!1 &5643596719895146687
 GameObject:
   m_ObjectHideFlags: 0
@@ -989,6 +946,107 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7115567819759284927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5017743644008061127}
+  - component: {fileID: 8457610955810588144}
+  - component: {fileID: 1146911558807956412}
+  - component: {fileID: 8078121351339454600}
+  m_Layer: 5
+  m_Name: Dialogue Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5017743644008061127
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7115567819759284927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 8723482651956380621}
+  - {fileID: 3460942540350147095}
+  m_Father: {fileID: 6344986284834697497}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &8457610955810588144
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7115567819759284927}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1146911558807956412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7115567819759284927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1620, y: 1080}
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 1
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &8078121351339454600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7115567819759284927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1001 &5373747150980818573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -996,10 +1054,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8723482651956380621}
     m_Modifications:
-    - target: {fileID: 306191073203887788, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
-      propertyPath: directory
-      value: Dialogue/nathan/multi
-      objectReference: {fileID: 0}
     - target: {fileID: 1722900228660773011, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -1050,11 +1104,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
---- !u!224 &6736147193481750046 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1722900228660773011, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
-  m_PrefabInstance: {fileID: 5373747150980818573}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5669096965221922849 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 306191073203887788, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
@@ -1066,6 +1115,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 779b91c313a2a4347815359320de5e14, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &6736147193481750046 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1722900228660773011, guid: bbe3c8ac416e36842b6fce8db428fa68, type: 3}
+  m_PrefabInstance: {fileID: 5373747150980818573}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6803483418189801850
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Gameplay Systems/Scene Loader.prefab
+++ b/Assets/Prefabs/Gameplay Systems/Scene Loader.prefab
@@ -200,7 +200,7 @@ MonoBehaviour:
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 2
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
@@ -317,6 +317,7 @@ GameObject:
   - component: {fileID: 5649544195503774738}
   - component: {fileID: 7907874822698731852}
   - component: {fileID: 5649544195503774736}
+  - component: {fileID: 4713901600583031713}
   m_Layer: 5
   m_Name: Scene Transition
   m_TagString: Untagged
@@ -340,7 +341,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -426,3 +427,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5649544195503774740}
   m_CullTransparentMesh: 1
+--- !u!114 &4713901600583031713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5649544195503774740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 3
+  m_AspectRatio: 1.5

--- a/Assets/Prefabs/UI/Level Selector.prefab
+++ b/Assets/Prefabs/UI/Level Selector.prefab
@@ -1143,9 +1143,9 @@ RectTransform:
   m_Father: {fileID: 255317763941158518}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 500, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 500, y: -64}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8561128337257286578
@@ -1401,8 +1401,8 @@ RectTransform:
   m_Father: {fileID: 255317763941158518}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 500, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1785,8 +1785,8 @@ GameObject:
   m_Component:
   - component: {fileID: 6485749173587818575}
   - component: {fileID: 6485749173587818572}
-  - component: {fileID: 6485749173587818573}
   - component: {fileID: 6485749173587819442}
+  - component: {fileID: 7966498818417818462}
   - component: {fileID: 6485749173587818574}
   m_Layer: 5
   m_Name: Level Selector
@@ -1812,7 +1812,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1837,29 +1837,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &6485749173587818573
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6485749173587819443}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 1
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
 --- !u!114 &6485749173587819442
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1877,6 +1854,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &7966498818417818462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485749173587819443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
 --- !u!114 &6485749173587818574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1889,8 +1880,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4347c267d03fa4ad495baa45d90582b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  unlockAllLevelsInDebug: 0
   menuHolder: {fileID: 0}
+  unlockAllLevelsInDebug: 0
 --- !u!1 &6485749174199209928
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Main Menu.prefab
+++ b/Assets/Prefabs/UI/Main Menu.prefab
@@ -36,9 +36,9 @@ RectTransform:
   m_Father: {fileID: 52073782557188898}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 320, y: -259.2}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 320, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4451995481138521620
@@ -170,7 +170,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8103548545015917303}
   - component: {fileID: 8103548545015917300}
-  - component: {fileID: 8103548545015917301}
+  - component: {fileID: 9075373244048674055}
   - component: {fileID: 8103548545015916810}
   - component: {fileID: 2211939458141237099}
   m_Layer: 5
@@ -201,7 +201,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -226,7 +226,7 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &8103548545015917301
+--- !u!114 &9075373244048674055
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -235,20 +235,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 8103548545015916811}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 1
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
 --- !u!114 &8103548545015916810
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/MenuHolder.prefab
+++ b/Assets/Prefabs/UI/MenuHolder.prefab
@@ -80,7 +80,7 @@ MonoBehaviour:
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 1
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96

--- a/Assets/Prefabs/UI/Pause Menu.prefab
+++ b/Assets/Prefabs/UI/Pause Menu.prefab
@@ -217,6 +217,7 @@ GameObject:
   - component: {fileID: 833575537544873610}
   - component: {fileID: 8448457512891995360}
   - component: {fileID: 6563010866287041012}
+  - component: {fileID: 150045810113670512}
   m_Layer: 0
   m_Name: Pause Menu UI
   m_TagString: Untagged
@@ -241,10 +242,10 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+  m_SizeDelta: {x: -277.1667, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &833575537544873610
 Canvas:
   m_ObjectHideFlags: 0
@@ -306,6 +307,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &150045810113670512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791399890371070272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
 --- !u!1001 &2719691335977663369
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Settings Menu.prefab
+++ b/Assets/Prefabs/UI/Settings Menu.prefab
@@ -314,8 +314,8 @@ GameObject:
   m_Component:
   - component: {fileID: 7000239815013155281}
   - component: {fileID: 3563267272390178711}
-  - component: {fileID: 5500812769526559365}
   - component: {fileID: 2129706775104524648}
+  - component: {fileID: 1978579624837979984}
   - component: {fileID: 5662769357552479857}
   m_Layer: 5
   m_Name: Settings Menu
@@ -342,7 +342,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -367,29 +367,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &5500812769526559365
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2461454065019411942}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1620, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 1
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
 --- !u!114 &2129706775104524648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -407,6 +384,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &1978579624837979984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2461454065019411942}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 3
+  m_AspectRatio: 1.5
 --- !u!114 &5662769357552479857
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraScaler.cs
+++ b/Assets/Scripts/CameraScaler.cs
@@ -20,16 +20,37 @@ public class CameraScaler : MonoBehaviour
     {
         int screenWidth = Screen.width; //px
         int screenHeight = Screen.height; //px
-        
+
         bool screenSizeChanged = screenWidth != lastScreenWidth || screenHeight != lastScreenHeight;
-        if (screenSizeChanged) {
-            // Center viewport and set aspect ratio to 3:2
-            int aspectRatioWidth = (int)(screenHeight * aspectRatio);
+        if (screenSizeChanged)
+        {
+            // Resize viewport and center it while maintaining the desired aspect ratio.
 
-            float newWidth = (float)aspectRatioWidth / screenWidth;
-            float newX = (1f - newWidth) / 2;
+            float newX = 0f;
+            float newY = 0f;
+            float newWidth = 1f;
+            float newHeight = 1f;
 
-            camera.rect = new Rect(newX, 0, newWidth, 1);
+            // Check whether we need to adjust horizontally or vertically by 
+            // comparing the desired aspect ratio and the current aspect ratio
+            float currentScreenAspectRatio = (float)screenWidth / screenHeight;
+
+            // If screen is too wide, we center horizontally
+            if (currentScreenAspectRatio > aspectRatio)
+            {
+                int aspectRatioWidth = (int)(screenHeight * aspectRatio);
+                newWidth = (float)aspectRatioWidth / screenWidth;
+                newX = (1f - newWidth) / 2;
+            }
+            // else, screen is too tall, so we center vertically
+            else
+            {
+                int aspectRatioHeight = (int)(screenWidth / aspectRatio);
+                newHeight = (float)aspectRatioHeight / screenHeight;
+                newY = (1f - newHeight) / 2;
+            }
+
+            camera.rect = new Rect(newX, newY, newWidth, newHeight);
 
             // Remember width and height to track changes
             lastScreenWidth = screenWidth;
@@ -44,14 +65,14 @@ public class CameraScaler : MonoBehaviour
     {
         // Remember viewport rect
         Rect oldViewportRect = camera.rect;
-        
+
         // New viewport rect to clear the whole screen
         Rect newViewportRect = new Rect(0, 0, 1, 1);
- 
+
         // Clear the pixels with black
         camera.rect = newViewportRect;
         GL.Clear(true, true, Color.black);
-       
+
         // Restore the previous viewport rect
         camera.rect = oldViewportRect;
     }


### PR DESCRIPTION
- In the UI prefabs:
  - Add Aspect Ratio Fitter component to scale and maintain 3:2 aspect ratio
  - Set Canvas Scaler scale mode to expand
- CameraScaler.cs
  - Add logic to shrink the viewport when the screen/window is too tall (previously we only accounted for horizontal scaling)