### PR TITLE
fix undefined menu manager preventing scene change

### DIFF
--- a/Assets/Prefabs/UI/Pause Menu.prefab
+++ b/Assets/Prefabs/UI/Pause Menu.prefab
@@ -219,7 +219,7 @@ GameObject:
   - component: {fileID: 6563010866287041012}
   - component: {fileID: 150045810113670512}
   m_Layer: 0
-  m_Name: Pause Menu UI
+  m_Name: Pause Menu Canvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/Scene Loading/SceneLoader.cs
+++ b/Assets/Scripts/Scene Loading/SceneLoader.cs
@@ -15,7 +15,6 @@ public class SceneLoader : MonoBehaviour
     // State variables
     bool isLoading = false;
     private AudioSource audioSource;
-    MenuManager menuManager;
 
     // Object references
     PersistentStoreManager storeManager;
@@ -23,8 +22,9 @@ public class SceneLoader : MonoBehaviour
     void Start()
     {
         audioSource = GetComponent<AudioSource>();
-        menuManager = FindObjectOfType<MenuManager>();
         storeManager = FindObjectOfType<PersistentStoreManager>();
+
+        StartCoroutine(handleSceneEntrance());
     }
     // Load the first level
     public void StartGame()
@@ -68,12 +68,22 @@ public class SceneLoader : MonoBehaviour
     // A coroutine that loads a given scene
     IEnumerator LoadSceneRoutine(int index)
     {
-        // Ensure only one scene gets loaded
+        // Ensure only one scene gets loaded at a time
         if (isLoading)
             yield break;
-            
+
         isLoading = true;
-        menuManager.enablePause(false);
+        yield return LoadAndEnterScene(index);
+
+        // We should be in the new scene now
+        yield return handleSceneEntrance();
+        isLoading = false;
+    }
+
+    private IEnumerator LoadAndEnterScene(int index)
+    {
+        // Disable the pause menu in the current scene
+        FindObjectOfType<MenuManager>()?.enablePause(false);
 
         // Set the transition color based on the level index.
         bool loadingToMenu = index == config.mainMenuBuildIndex;
@@ -95,15 +105,17 @@ public class SceneLoader : MonoBehaviour
         yield return new WaitForSeconds(config.minLoadingTime);
         yield return new WaitUntil(() => asyncLoad.progress >= 0.9f);
         asyncLoad.allowSceneActivation = true;
+    }
 
-        TrySetLevelReached(index);
+    private IEnumerator handleSceneEntrance()
+    {
+        TrySetLevelReached(GetCurrentSceneIndex());
 
-        // Start the transition animation 
+        // Start the transition animation
         yield return transition.FadeIn();
 
-        isLoading = false;
-        menuManager = FindObjectOfType<MenuManager>();
-        menuManager.enablePause(true);
+        // Enable the pause menu in the new scene
+        FindObjectOfType<MenuManager>()?.enablePause(true);
     }
 
     // Returns the current scene index

--- a/Assets/Scripts/UI/MenuManager.cs
+++ b/Assets/Scripts/UI/MenuManager.cs
@@ -14,37 +14,34 @@ public class MenuManager : MonoBehaviour
     [SerializeField] GameObject pauseMenu;
     [SerializeField] GameObject levelMenu;
 
-    void Start()
+    // Public functions for OnClick() to call
+    public void enableSettings(bool enable)
     {
-        // Only enable Main Menu Canvas if we're in the Main Menu Scene
-        if (GetCurrentSceneIndex() == config.mainMenuBuildIndex) {
-            mainMenu.SetActive(true);
+        if (settingsMenu)
+            settingsMenu.SetActive(enable);
+        else
+            Debug.Log($"Tried to set settings menu enabled to {enable} but it's undefined");
+    }
+    public void enablePause(bool enable)
+    {
+        if (pauseMenu)
+        {
+            if (!(GetCurrentSceneIndex() == config.mainMenuBuildIndex))
+                pauseMenu.SetActive(enable);
+            else
+                Debug.Log($"Tried to set pause menu enabled to {enable} but we're in the main menu");
         }
-        // Disable all other canvases
-        enableSettings(false);
-        enableLevels(false);
-        enablePause(false);
+        else
+            Debug.Log($"Tried to set pause menu enabled to {enable} but it's undefined");
+    }
+    public void enableLevels(bool enable)
+    {
+        if (levelMenu)
+            levelMenu.SetActive(enable);
+        else
+            Debug.Log($"Tried to set level menu enabled to {enable} but it's undefined");
     }
 
-    // Public functions for OnClick() to call
-    public void enableSettings(bool enable) {
-        if (settingsMenu) 
-            settingsMenu.SetActive(enable);
-        else 
-            Debug.Log("Tried to enable settings menu but it's undefined");
-    }
-    public void enablePause(bool enable) {
-        if (pauseMenu && !(GetCurrentSceneIndex() == config.mainMenuBuildIndex)) 
-            pauseMenu.SetActive(enable);
-        else 
-            Debug.Log("Tried to enable pause menu but it's undefined");
-    }
-    public void enableLevels(bool enable) {
-        if (levelMenu) 
-            levelMenu.SetActive(enable);
-        else 
-            Debug.Log("Tried to enable levels menu but it's undefined");
-    }
     // Shamelessly stolen from another script
     private int GetCurrentSceneIndex()
     {


### PR DESCRIPTION
- SceneLoader
  - change logic to always get the latest instance of the MenuManager
  - split load scene coroutine into two parts/coroutines
    - part 1 runs in old scene to load new scene
    - part 2 runs in new scene to handle the transition/entrance into the new scene
  - run part 2 in Start() so starting the game in the editor will still allow bringing up the pause menu
  - use safe nav operator in case there is no menu object
- MenuManager
  - update debug.logs
  - remove start() logic that manages enabling/disabling the individual menus
    - we can do this in each scene instead as prefab overrides. no need to do it in code.