### PR TITLE
allow debug build to unlock all levels + fix saving in irl cutscene

### DIFF
--- a/Assets/Prefabs/UI/Menu Manager.prefab
+++ b/Assets/Prefabs/UI/Menu Manager.prefab
@@ -667,6 +667,10 @@ PrefabInstance:
       propertyPath: menuHolder
       value: 
       objectReference: {fileID: 4541007427616867141}
+    - target: {fileID: 6485749173587818574, guid: 336ca3a3518c6584099bd7e579f13204, type: 3}
+      propertyPath: unlockAllLevelsInDebug
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6485749173587818575, guid: 336ca3a3518c6584099bd7e579f13204, type: 3}
       propertyPath: m_RootOrder
       value: 2

--- a/Assets/Scripts/Saving and Loading/GameManager.cs
+++ b/Assets/Scripts/Saving and Loading/GameManager.cs
@@ -61,14 +61,21 @@ public class GameManager : MonoBehaviour
         int currentBuildIndex = SceneManager.GetActiveScene().buildIndex;
         Global.Level currentLevel = Global.GetLevelFromBuildIndex(currentBuildIndex);
 
+        // Ensure this is a scene that we should be saving progress for
         if (currentLevel == Global.Level.NONE) {
             Debug.Log("Tried to save but current scene is not a game level");
             return;
         }
-
-        newGameData.level = currentLevel;
-        newGameData.playerData = player?.Capture();
         
+        // Capture level state
+        newGameData.level = currentLevel;
+
+        // Capture player state
+        if (player != null) {
+            newGameData.playerData = player?.Capture();
+        }
+        
+        // Capture checkpoint state
         newGameData.checkpointData = new List<SerializableCheckpointData>();
         foreach (CheckpointData checkpoint in checkpointData)
         {
@@ -77,6 +84,7 @@ public class GameManager : MonoBehaviour
             }
         }
         
+        // Capture cutscene state
         newGameData.cutsceneData = new List<SerializableCutsceneData>();
         foreach (CutsceneData cutscene in cutsceneData)
         {

--- a/Assets/Scripts/Saving and Loading/PersistentStoreManager.cs
+++ b/Assets/Scripts/Saving and Loading/PersistentStoreManager.cs
@@ -10,7 +10,6 @@ using UnityEngine.SceneManagement;
 public class PersistentStore
 {
     public HashSet<Global.Level> reachedLevels = new HashSet<Global.Level>();
-    // public bool gameCompleted = false;
 }
 
 [RequireComponent(typeof(Singleton))]
@@ -65,24 +64,16 @@ public class PersistentStoreManager : MonoBehaviour
     // Below are mutators for the persistent store
     public void AddLevelReached(Global.Level level)
     {
-        store.reachedLevels.Add(level);
-        Save();
+        if (!store.reachedLevels.Contains(level))
+        {
+            store.reachedLevels.Add(level);
+            Save();
+        }
     }
-
-    // public void SetGameCompleted(bool value)
-    // {
-    //     store.gameCompleted = value;
-    //     Save();
-    // }
 
     // Below are getters for the persistent store
     public bool QueryLevelReached(Global.Level level)
     {
         return store.reachedLevels.Contains(level);
     }
-
-    // public bool GetGameCompleted()
-    // {
-    //     return store.gameCompleted;
-    // }
 }

--- a/Assets/Scripts/UI/Level Selector/LevelSelector.cs
+++ b/Assets/Scripts/UI/Level Selector/LevelSelector.cs
@@ -11,21 +11,18 @@ public class LevelSelector : MonoBehaviour
     bool unlockAllLevels;
 
     [SerializeField] MenuManager menuHolder;
-    
-    // Configuration parameters
-    // For dev/debug only
-    [Header("The options below will only take effect in Debug mode")]
-    [SerializeField] private bool unlockAllLevelsInDebug = false;
 
-    void Start()
+    void Awake()
     {
         sceneLoader = FindObjectOfType<SceneLoader>();
         storeManager = FindObjectOfType<PersistentStoreManager>();
+    }
 
-        if (Debug.isDebugBuild && unlockAllLevelsInDebug)
-        {
-            unlockAllLevels = true;
-        }
+    void OnEnable()
+    {
+        // Debug build only:
+        // If left shift is held while the level selector opens, all leves are unlocked
+        unlockAllLevels = Debug.isDebugBuild && Input.GetKey(KeyCode.LeftShift);
     }
 
     public bool LevelReached(Global.Level level)

--- a/Assets/Scripts/UI/Level Selector/LevelSelectorButton.cs
+++ b/Assets/Scripts/UI/Level Selector/LevelSelectorButton.cs
@@ -10,14 +10,20 @@ public class LevelSelectorButton : MonoBehaviour
 
     // References
     [SerializeField] public LevelSelector levelSelector;
+    private Button button;
 
     // Start is called before the first frame update
-    void Start()
+    void Awake()
+    {
+        button = GetComponent<Button>();
+    }
+
+    void OnEnable()
     {
         // Enable the button only if there exists a game save that indicates
         // the level has already been reached in the past
         bool levelReached = levelSelector.LevelReached(level);
-        GetComponent<Button>().interactable = levelReached;
+        button.interactable = levelReached;
     }
 
     public void OnClick()


### PR DESCRIPTION
- GameManager
  - account for if the PlayerData object is undefined
- PersistentStoreManager
  - only mutate reachedLevels and save to disk if the level to add isn't already in the set
- LevelSelector, LevelSelectorButton
  - if in debug build, holding left shift while level selector menu opens will temporarily unlock all levels