### PR TITLE
add and use sfx directory attribute in dialogue object

### DIFF
--- a/Assets/Dialogue/1 Cutscene Teacher/1.asset
+++ b/Assets/Dialogue/1 Cutscene Teacher/1.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 1
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/teacher/single
   entries:
   - avatar: {fileID: 0}
     content: Hey Nathan?

--- a/Assets/Dialogue/1 Cutscene Teacher/2.asset
+++ b/Assets/Dialogue/1 Cutscene Teacher/2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/teacher/single
   entries:
   - avatar: {fileID: 0}
     content: Oh hello Nathan.

--- a/Assets/Dialogue/1 Cutscene Teacher/3.asset
+++ b/Assets/Dialogue/1 Cutscene Teacher/3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/teacher/single
   entries:
   - avatar: {fileID: 0}
     content: I just wanted to ask you, is everything alright?

--- a/Assets/Dialogue/2 Cutscene Claire/2.asset
+++ b/Assets/Dialogue/2 Cutscene Claire/2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: Nathan?

--- a/Assets/Dialogue/3 Cutscene Claire Left/1.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/1.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 1
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: Hey Nathan,

--- a/Assets/Dialogue/3 Cutscene Claire Left/2.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: How've you been, man?
@@ -47,7 +48,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Look, I know you said you wanted space, and that's one thing, I get it.
+    content: Look, I know you said you wanted space, and that's one thing, I get
+      it.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/3 Cutscene Claire Left/3.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: I just don't get you man. Like did I do something wrong?
@@ -31,7 +32,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: It feels like I'm talking to myself at this point, and I don't know what to do.
+    content: It feels like I'm talking to myself at this point, and I don't know
+      what to do.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/3 Cutscene Claire Left/4.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/4.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: Look, I know you're sad about him, okay? And I can't blame you.
@@ -31,7 +32,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And you know me, you know I don't like talking about this kinda stuff. Y'know I'm not that kind of person.
+    content: And you know me, you know I don't like talking about this kinda stuff.
+      Y'know I'm not that kind of person.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -71,7 +73,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Like out of all times you could've picked to run off, right when I needed you most, you left.
+    content: Like out of all times you could've picked to run off, right when I needed
+      you most, you left.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/3 Cutscene Claire Left/5.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/5.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: So look man, just tell me, did I do something?

--- a/Assets/Dialogue/3 Cutscene Claire Left/6.asset
+++ b/Assets/Dialogue/3 Cutscene Claire Left/6.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/single
   entries:
   - avatar: {fileID: 0}
     content: Alright, fine.

--- a/Assets/Dialogue/4 Cutscene Mike Blocked/1.asset
+++ b/Assets/Dialogue/4 Cutscene Mike Blocked/1.asset
@@ -13,13 +13,15 @@ MonoBehaviour:
   m_Name: 1
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/single
   entries:
   - avatar: {fileID: 0}
     content: Hey Nathan, sorry it's kinda late
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But if you're still up, I just need to talk to you for a bit, if that's alright
+    content: But if you're still up, I just need to talk to you for a bit, if that's
+      alright
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/4 Cutscene Mike Blocked/2.asset
+++ b/Assets/Dialogue/4 Cutscene Mike Blocked/2.asset
@@ -13,13 +13,15 @@ MonoBehaviour:
   m_Name: 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/single
   entries:
   - avatar: {fileID: 0}
     content: Sorry bout all of this, I know I keep texting a lot
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I swear I don't want to come off as like clingy and weird, I'm not trying to be that guy
+    content: I swear I don't want to come off as like clingy and weird, I'm not trying
+      to be that guy
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -31,8 +33,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I know you and Claire are like on a silent treatment basis right
-      now
+    content: I know you and Claire are like on a silent treatment basis right now
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -48,11 +49,13 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And I know sometimes it seems like she doesn't care, but she really does man
+    content: And I know sometimes it seems like she doesn't care, but she really
+      does man
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And I'm not really sure what exactly happened between you guys last week, but when I asked her about it, she just sounded really upset
+    content: And I'm not really sure what exactly happened between you guys last
+      week, but when I asked her about it, she just sounded really upset
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -60,7 +63,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Look I'm not trying to, like, guilt you into talking to her again. I know that'll probably make it worse
+    content: Look I'm not trying to, like, guilt you into talking to her again. I
+      know that'll probably make it worse
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -68,11 +72,13 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Don't think she'd like me talking about it, at all, especially with you here, but here I am, I guess.
+    content: Don't think she'd like me talking about it, at all, especially with
+      you here, but here I am, I guess.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And look, I get it's your guys' personal business. If you want me to just stay out of it, just tell me, I'll stop bringing it up.
+    content: And look, I get it's your guys' personal business. If you want me to
+      just stay out of it, just tell me, I'll stop bringing it up.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -80,7 +86,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: It's just, 
+    content: It's just,
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -88,12 +94,11 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I'm worried about you too man, I haven't seen you in like,
-      weeks, even
+    content: I'm worried about you too man, I haven't seen you in like, weeks, even
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: First, he's gone, and then all of this happening right now 
+    content: First, he's gone, and then all of this happening right now
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/4 Cutscene Mike Blocked/3.asset
+++ b/Assets/Dialogue/4 Cutscene Mike Blocked/3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/single
   entries:
   - avatar: {fileID: 0}
     content: I'll be honest with you, I don't know what to do anymore man
@@ -23,11 +24,12 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Just please pick up the phone when you can, ok? Please let me know you can see this
+    content: Just please pick up the phone when you can, ok? Please let me know you
+      can see this
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: You don't even have to say much if you don't want to, I get it 
+    content: You don't even have to say much if you don't want to, I get it
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -43,7 +45,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I'll stop texting and talking to you, and you don't even have to see or talk to me ever again 
+    content: I'll stop texting and talking to you, and you don't even have to see
+      or talk to me ever again
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Claire Level/0 Meeting Claire.asset
+++ b/Assets/Dialogue/Claire Level/0 Meeting Claire.asset
@@ -13,9 +13,10 @@ MonoBehaviour:
   m_Name: 0 Meeting Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}
-    content: !
+    content: '!'
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}

--- a/Assets/Dialogue/Claire Level/1 Talk to Claire.asset
+++ b/Assets/Dialogue/Claire Level/1 Talk to Claire.asset
@@ -13,13 +13,15 @@ MonoBehaviour:
   m_Name: 1 Talk to Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d72e7e17a4a927343afc59b717f37150, type: 3}
     content: Oh hey man.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 62f120283f8451f4b96a645b705ae3dc, type: 3}
-    content: I forgot to ask back there, but just curious, how long have you been here?
+    content: I forgot to ask back there, but just curious, how long have you been
+      here?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}

--- a/Assets/Dialogue/Claire Level/10.1 Claire Death.asset
+++ b/Assets/Dialogue/Claire Level/10.1 Claire Death.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10.1 Claire Death
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: e3b1772084005c74081231faabc1df45, type: 3}
     content: ...

--- a/Assets/Dialogue/Claire Level/10.2 Claire Death.asset
+++ b/Assets/Dialogue/Claire Level/10.2 Claire Death.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10.2 Claire Death
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 562d2216010d6dc438e0966511e83259, type: 3}
     content: Hey, don't worry about me, man.

--- a/Assets/Dialogue/Claire Level/2 Puzzle One Claire.asset
+++ b/Assets/Dialogue/Claire Level/2 Puzzle One Claire.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2 Puzzle One Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}
     content: Oh hey man, what's up?
@@ -55,7 +56,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}
-    content: Welp, you could probably just draw something, maybe that ramp could help?
+    content: Welp, you could probably just draw something, maybe that ramp could
+      help?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: d72e7e17a4a927343afc59b717f37150, type: 3}

--- a/Assets/Dialogue/Claire Level/3 Puzzle Two Claire.asset
+++ b/Assets/Dialogue/Claire Level/3 Puzzle Two Claire.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3 Puzzle Two Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d72e7e17a4a927343afc59b717f37150, type: 3}
     content: Oh hey again man.

--- a/Assets/Dialogue/Claire Level/4.1 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/4.1 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.1 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}
     content: Not gonna lie man, dunno how to help you with this one.

--- a/Assets/Dialogue/Claire Level/4.2 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/4.2 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.2 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d72e7e17a4a927343afc59b717f37150, type: 3}
     content: Here, just jump up and I'll catch you.

--- a/Assets/Dialogue/Claire Level/4.3 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/4.3 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.3 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 1f1d08cd1b02e714eb5a4f76de80c062, type: 3}
     content: Alright, alright. You're up, you're done.

--- a/Assets/Dialogue/Claire Level/5.1 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.1 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.1 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 0ab2cd1dcf1602e4297a043c03a59b77, type: 3}
     content: ...

--- a/Assets/Dialogue/Claire Level/5.2 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.2 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.2 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d72e7e17a4a927343afc59b717f37150, type: 3}
     content: Look, we're literally fine.

--- a/Assets/Dialogue/Claire Level/5.3 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.3 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.3 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 62f120283f8451f4b96a645b705ae3dc, type: 3}
     content: You really wanna draw the chair?

--- a/Assets/Dialogue/Claire Level/5.4 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.4 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.4 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}
     content: Well, it's-

--- a/Assets/Dialogue/Claire Level/5.5 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.5 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.5 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}
     content: Huh, it's not that bad actually

--- a/Assets/Dialogue/Claire Level/5.6 Chair.asset
+++ b/Assets/Dialogue/Claire Level/5.6 Chair.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.6 Chair
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d0c83e0e892f4d647bf93eb7f2e617c6, type: 3}
     content: Alright, I'm good for now, let's keep going.

--- a/Assets/Dialogue/Claire Level/6.1 Background Cutscene.asset
+++ b/Assets/Dialogue/Claire Level/6.1 Background Cutscene.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.1 Background Cutscene
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 1f1d08cd1b02e714eb5a4f76de80c062, type: 3}
     content: I swear these scribbles, they're getting more difficult.

--- a/Assets/Dialogue/Claire Level/6.2 Background Cutscene.asset
+++ b/Assets/Dialogue/Claire Level/6.2 Background Cutscene.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.2 Background Cutscene
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}
     content: Oh hey, hold up.

--- a/Assets/Dialogue/Claire Level/6.3 Background.asset
+++ b/Assets/Dialogue/Claire Level/6.3 Background.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.3 Background
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 979c5c1a9f5b0f7419c033ded6c30ca4, type: 3}
     content: That's definitely new... I haven't seen those mountains before.
@@ -51,7 +52,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}
-    content:  Haven't found a way out from those scribbles
+    content: Haven't found a way out from those scribbles
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: f01281df037fc6f4d943e166acb86a1f, type: 3}

--- a/Assets/Dialogue/Claire Level/6.4 Background.asset
+++ b/Assets/Dialogue/Claire Level/6.4 Background.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.4 Background
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: d6007de435371f1418448cc160af4897, type: 3}
     content: Alright man,

--- a/Assets/Dialogue/Claire Level/7 Puzzle Three Claire.asset
+++ b/Assets/Dialogue/Claire Level/7 Puzzle Three Claire.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 7 Puzzle Three Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: fb7ede7fd0b9b704f9a069aadde170f5, type: 3}
     content: Hey man, whew,

--- a/Assets/Dialogue/Claire Level/8 Puzzle Four Claire.asset
+++ b/Assets/Dialogue/Claire Level/8 Puzzle Four Claire.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 8 Puzzle Four Claire
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: fb7ede7fd0b9b704f9a069aadde170f5, type: 3}
     content: Hey,

--- a/Assets/Dialogue/Claire Level/9.1 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/9.1 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.1 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: 3f23afdf7cc6c3a4f8b3a7586c0dea88, type: 3}
     content: I'm alright, I'm alright, I'm alright, just give me a sec-

--- a/Assets/Dialogue/Claire Level/9.2 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/9.2 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.2 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: a737ebcfd17faf8488106b69ab2251a2, type: 3}
     content: God, I know I was joking, but I swear something actually broke.

--- a/Assets/Dialogue/Claire Level/9.3 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/9.3 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.3 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: fb7ede7fd0b9b704f9a069aadde170f5, type: 3}
     content: Alright, come on.

--- a/Assets/Dialogue/Claire Level/9.4 Cliff.asset
+++ b/Assets/Dialogue/Claire Level/9.4 Cliff.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.4 Cliff
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/claire/multi
   entries:
   - avatar: {fileID: 21300000, guid: a737ebcfd17faf8488106b69ab2251a2, type: 3}
     content: I'm fine. I'm just-

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/1.1 Meet Mike.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/1.1 Meet Mike.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 1.1 Meet Mike
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 0}
     content: WATCH OUT!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/1.2 Meet Mike.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/1.2 Meet Mike.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 1.2 Meet Mike
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: a7f0351f8217c3848b46497ad3cf2923, type: 3}
     content: Jeez, that was close! You alright? Did it get ya?
@@ -35,7 +36,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
-    content: And I didn't miss it this time! Nice! 
+    content: And I didn't miss it this time! Nice!
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: ff565c98b7202874ab25931e0fda4477, type: 3}

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/2.1 Puzzle 2.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/2.1 Puzzle 2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2.1 Puzzle 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}
     content: Heyo man! Glad to see ya.
@@ -31,6 +32,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}
-    content: Can you taking a look at what's up there? Maybe there's something we can use.
+    content: Can you taking a look at what's up there? Maybe there's something we
+      can use.
     useCPS: 0
     CPS: 0

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/2.2 Puzzle 2.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/2.2 Puzzle 2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2.2 Puzzle 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
     content: Nice man!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/2.3 Puzzle 2.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/2.3 Puzzle 2.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2.3 Puzzle 2
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
     content: What'd I tell ya, still got it!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/3.1 Puzzle 3.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/3.1 Puzzle 3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3.1 Puzzle 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
     content: Hey! Look what I found!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/3.2 Puzzle 3.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/3.2 Puzzle 3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3.2 Puzzle 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
     content: Well, here's the ramp!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/3.3 Puzzle 3.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/3.3 Puzzle 3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3.3 Puzzle 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: a7f0351f8217c3848b46497ad3cf2923, type: 3}
     content: OH WAIT!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/3.4 Puzzle 3.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/3.4 Puzzle 3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3.4 Puzzle 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: d04238c316d2c4a489e5978beb699df8, type: 3}
     content: Alright! All ready for ya, do your thing!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/3.5 Puzzle 3.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/3.5 Puzzle 3.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3.5 Puzzle 3
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: a7f0351f8217c3848b46497ad3cf2923, type: 3}
     content: Hey, it worked! Nice!
@@ -23,7 +24,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}
-    content: 'I kinda just thought "hit orange thing with blue thing" and something would happen.'
+    content: I kinda just thought "hit orange thing with blue thing" and something
+      would happen.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/4.1 Puzzle 4.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/4.1 Puzzle 4.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.1 Puzzle 4
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: b3cd9d4f66e6a0949b3992d6aaee2afd, type: 3}
     content: Seriously? Three guys, lined up back to back?

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/4.2 Puzzle 4.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/4.2 Puzzle 4.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.2 Puzzle 4
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 188e0f0a0df12534d9a8ef87d5cc2b16, type: 3}
     content: Hey man, these guys are getting kinda hard to hold down!

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/4.3 Puzzle 4.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/4.3 Puzzle 4.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 4.3 Puzzle 4
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 08d41b042bb73e14ea6d3b74cefb7c3d, type: 3}
     content: Thanks man, those scribbles were out of control.

--- a/Assets/Dialogue/Mike Level/Mike Pt 1/5.1 Mike Tired.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 1/5.1 Mike Tired.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5.1 Mike Tired
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}
     content: Hey man!

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/10.1 Pre-Death.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/10.1 Pre-Death.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10.1 Pre-Death
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 08d41b042bb73e14ea6d3b74cefb7c3d, type: 3}
     content: Well... I think we lost them, thank goodness

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/10.2 Pre-Death.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/10.2 Pre-Death.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10.2 Pre-Death
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 08d41b042bb73e14ea6d3b74cefb7c3d, type: 3}
     content: We fell pretty far down, away from them, but I thought some would come

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/10.3 Pre-Death.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/10.3 Pre-Death.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10.3 Pre-Death
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 24dc9ba2fa84d5e449b0614a591f3fa0, type: 3}
     content: Dunno where we landed, really. Definitely haven't seen this before.

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/6.1 Mike saves Stickman.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/6.1 Mike saves Stickman.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.1 Mike saves Stickman
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 037910a8f9bebc941b21b55594fa7935, type: 3}
     content: Hey man, I got you, they're all gone now.

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/7.1 Stickman Falls.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/7.1 Stickman Falls.asset
@@ -12,14 +12,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1346f42873dd9524ba40401787dfb1d6, type: 3}
   m_Name: 7.1 Stickman Falls
   m_EditorClassIdentifier: 
-  CPS: 30s
+  CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 24dc9ba2fa84d5e449b0614a591f3fa0, type: 3}
     content: Hey man, can you come take a look at this real quick?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 24dc9ba2fa84d5e449b0614a591f3fa0, type: 3}
-    content: There's a bunch of scribbles up there, but I couldn't find any of those drawing boxes to get around them.
+    content: There's a bunch of scribbles up there, but I couldn't find any of those
+      drawing boxes to get around them.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 21300000, guid: 24dc9ba2fa84d5e449b0614a591f3fa0, type: 3}

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/7.2 Stickman Falls.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/7.2 Stickman Falls.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 7.2 Stickman Falls
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 237afd46ce8f9564a88fd46feeb40598, type: 3}
     content: STICKMAN!

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/7.3 Stickman Falls.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/7.3 Stickman Falls.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 7.3 Stickman Falls
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 237afd46ce8f9564a88fd46feeb40598, type: 3}
     content: Are you okay dude?! You hurt?!

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/8.1 Mike Meet Up Again.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/8.1 Mike Meet Up Again.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 8.1 Mike Meet Up Again
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 6f95a52c3a60d85479bae94c28d0d5da, type: 3}
     content: OH MY GOD, you made it! You're okay.

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/9.1 Puzzle 6.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/9.1 Puzzle 6.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.1 Puzzle 6
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 24dc9ba2fa84d5e449b0614a591f3fa0, type: 3}
     content: So, y'know how to get past this? There's a drawing box but-

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/9.2 Puzzle 6.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/9.2 Puzzle 6.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.2 Puzzle 6
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: a7f0351f8217c3848b46497ad3cf2923, type: 3}
     content: BEHIND YOU!

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/9.3 Puzzle 6.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/9.3 Puzzle 6.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.3 Puzzle 6
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 27a1f02b7a9c6ff4a95f9de3e3f6c664, type: 3}
     content: I GOT IT! I got it!

--- a/Assets/Dialogue/Mike Level/Mike Pt 2/9.4 Puzzle 6.asset
+++ b/Assets/Dialogue/Mike Level/Mike Pt 2/9.4 Puzzle 6.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 9.4 Puzzle 6
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/mike/multi
   entries:
   - avatar: {fileID: 21300000, guid: 188e0f0a0df12534d9a8ef87d5cc2b16, type: 3}
     content: Did you do it? I heard the bridge come down!

--- a/Assets/Dialogue/Nathan Level/1 Empty Hall.asset
+++ b/Assets/Dialogue/Nathan Level/1 Empty Hall.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 1 Empty Hall
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Why won't you give up?

--- a/Assets/Dialogue/Nathan Level/10 Back to Classroom.asset
+++ b/Assets/Dialogue/Nathan Level/10 Back to Classroom.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10 Back to Classroom
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Yet you always came to me.
@@ -35,7 +36,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And of course, I tried my best to help. You always had great ideas, and I just wanted to help, y'know?
+    content: And of course, I tried my best to help. You always had great ideas,
+      and I just wanted to help, y'know?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -43,7 +45,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I don't really think my input was all that helpful in the end, to be honest.
+    content: I don't really think my input was all that helpful in the end, to be
+      honest.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -55,6 +58,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I didn't really get it, but it seemed to make you happy, so I just kept finding things to tell you.
+    content: I didn't really get it, but it seemed to make you happy, so I just kept
+      finding things to tell you.
     useCPS: 0
     CPS: 0

--- a/Assets/Dialogue/Nathan Level/11 Home.asset
+++ b/Assets/Dialogue/Nathan Level/11 Home.asset
@@ -13,17 +13,19 @@ MonoBehaviour:
   m_Name: 11 Home
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: It became like a routine for me.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I'd wake up, way too tired, and I just wanted to skip class and sit in bed all day.
+    content: I'd wake up, way too tired, and I just wanted to skip class and sit
+      in bed all day.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: "But I'd just keep telling myself when I woke up:"
+    content: 'But I''d just keep telling myself when I woke up:'
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/12 Walk to School.asset
+++ b/Assets/Dialogue/Nathan Level/12 Walk to School.asset
@@ -13,9 +13,11 @@ MonoBehaviour:
   m_Name: 12 Walk to School
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
-    content: Funny thing is, I think I started remembering things better because of it.
+    content: Funny thing is, I think I started remembering things better because
+      of it.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -31,6 +33,7 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But It'd be small things I could remember, little things that reminded me of something you said the day before.
+    content: But It'd be small things I could remember, little things that reminded
+      me of something you said the day before.
     useCPS: 0
     CPS: 0

--- a/Assets/Dialogue/Nathan Level/13 Cafeteria.asset
+++ b/Assets/Dialogue/Nathan Level/13 Cafeteria.asset
@@ -13,21 +13,25 @@ MonoBehaviour:
   m_Name: 13 Cafeteria
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: It became the highlight of my day, to be honest.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: And then I'd be catching myself pointing these things out around Claire and Mike.
+    content: And then I'd be catching myself pointing these things out around Claire
+      and Mike.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Hell, I didn't even notice until they started poking fun at me, Claire kept calling me your superfan.
+    content: Hell, I didn't even notice until they started poking fun at me, Claire
+      kept calling me your superfan.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But then of course Claire started getting really invested, and she was always asking you all these questions about your stories.
+    content: But then of course Claire started getting really invested, and she was
+      always asking you all these questions about your stories.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -39,11 +43,13 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Funny thing too, sometimes you'd say a word, and I'd have no idea what it meant,
+    content: Funny thing too, sometimes you'd say a word, and I'd have no idea what
+      it meant,
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: and I didn't wanna look dumb in front of you, so I'd go and ask Claire what it meant.
+    content: and I didn't wanna look dumb in front of you, so I'd go and ask Claire
+      what it meant.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -59,7 +65,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But I swear, I'd learn it, and then I'd come to class and I'd mention it, and by god,
+    content: But I swear, I'd learn it, and then I'd come to class and I'd mention
+      it, and by god,
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -67,7 +74,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I never really saw what those little moments meant back then, but I get it now.
+    content: I never really saw what those little moments meant back then, but I
+      get it now.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/14 Confronting.asset
+++ b/Assets/Dialogue/Nathan Level/14 Confronting.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 14 Confronting
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: I really didn't want to show you this.

--- a/Assets/Dialogue/Nathan Level/15 Park.asset
+++ b/Assets/Dialogue/Nathan Level/15 Park.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 15 Park
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: We were gonna go to the park that weekend, all four of us.
@@ -37,11 +38,13 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: She wasn't gonna, but I was able to convince her to let you pick the songs this time.
+    content: She wasn't gonna, but I was able to convince her to let you pick the
+      songs this time.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But you had a club meeting, or meeting with a teacher, or something, I can't remember.
+    content: But you had a club meeting, or meeting with a teacher, or something,
+      I can't remember.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/16 Leave Park.asset
+++ b/Assets/Dialogue/Nathan Level/16 Leave Park.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 16 Leave Park
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: It had been half an hour.

--- a/Assets/Dialogue/Nathan Level/17 Drive to Bus Stop.asset
+++ b/Assets/Dialogue/Nathan Level/17 Drive to Bus Stop.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 17 Drive to Bus Stop
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: So I drove down to the school, down to the bus stop...

--- a/Assets/Dialogue/Nathan Level/18 Bus Stop.asset
+++ b/Assets/Dialogue/Nathan Level/18 Bus Stop.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 18 Bus Stop
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: I don't think I'll ever get that image out of my head.

--- a/Assets/Dialogue/Nathan Level/19 Confronting Nathan.asset
+++ b/Assets/Dialogue/Nathan Level/19 Confronting Nathan.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 19 Confronting Nathan
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: ...

--- a/Assets/Dialogue/Nathan Level/2 Empty Hall.asset
+++ b/Assets/Dialogue/Nathan Level/2 Empty Hall.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 2 Empty Hall
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Why do you keep going?

--- a/Assets/Dialogue/Nathan Level/20 Nathan Hug.asset
+++ b/Assets/Dialogue/Nathan Level/20 Nathan Hug.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 20 Nathan Hug
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Thank you...

--- a/Assets/Dialogue/Nathan Level/3 Empty Hall.asset
+++ b/Assets/Dialogue/Nathan Level/3 Empty Hall.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 3 Empty Hall
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Well, this is it. I don't have anything else to show you.

--- a/Assets/Dialogue/Nathan Level/4 Empty Hall.asset
+++ b/Assets/Dialogue/Nathan Level/4 Empty Hall.asset
@@ -13,9 +13,11 @@ MonoBehaviour:
   m_Name: 4 Empty Hall
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
-    content: When I first started all of this, I just thought it'd help a little, y'know?
+    content: When I first started all of this, I just thought it'd help a little,
+      y'know?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/5 Empty Hallway.asset
+++ b/Assets/Dialogue/Nathan Level/5 Empty Hallway.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 5 Empty Hallway
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: I know I should be better than this.
@@ -37,7 +38,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But... I can't. After everything that's happened, it isn't the same anymore.
+    content: But... I can't. After everything that's happened, it isn't the same
+      anymore.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -58,7 +60,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: Someone could disappear, just like that, and you could just forget about them?
+    content: Someone could disappear, just like that, and you could just forget about
+      them?
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/6.1 Tearing Paper.asset
+++ b/Assets/Dialogue/Nathan Level/6.1 Tearing Paper.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.1 Tearing Paper
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Well, that sure worked, didn't it?

--- a/Assets/Dialogue/Nathan Level/6.2 Tearing Paper.asset
+++ b/Assets/Dialogue/Nathan Level/6.2 Tearing Paper.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.2 Tearing Paper
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: We'll never get to sit together at lunch anymore.

--- a/Assets/Dialogue/Nathan Level/6.3 Tearing Paper.asset
+++ b/Assets/Dialogue/Nathan Level/6.3 Tearing Paper.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.3 Tearing Paper
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Hell, before I met you, I didn't even see a reason to keep going.
@@ -27,10 +28,12 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But if I leave today, at least I'll leave knowing what it was like having a friend like you.
+    content: But if I leave today, at least I'll leave knowing what it was like having
+      a friend like you.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I just wish I could've been a better friend. A friend that deserved you.
+    content: I just wish I could've been a better friend. A friend that deserved
+      you.
     useCPS: 0
     CPS: 0

--- a/Assets/Dialogue/Nathan Level/6.4 Tearing Paper.asset
+++ b/Assets/Dialogue/Nathan Level/6.4 Tearing Paper.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.4 Tearing Paper
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: But I can't do this anymore.

--- a/Assets/Dialogue/Nathan Level/6.5 Tearing Paper.asset
+++ b/Assets/Dialogue/Nathan Level/6.5 Tearing Paper.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 6.5 Tearing Paper
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: I can't.

--- a/Assets/Dialogue/Nathan Level/7 Empty Hallway.asset
+++ b/Assets/Dialogue/Nathan Level/7 Empty Hallway.asset
@@ -13,9 +13,11 @@ MonoBehaviour:
   m_Name: 7 Empty Hallway
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
-    content: I just hope you enjoyed this little world. Well, what's left of it at least.
+    content: I just hope you enjoyed this little world. Well, what's left of it at
+      least.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -67,7 +69,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: God, I don't know why I'm like this, if I knew why I swear I'd do something about it,
+    content: God, I don't know why I'm like this, if I knew why I swear I'd do something
+      about it,
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/8 Classroom.asset
+++ b/Assets/Dialogue/Nathan Level/8 Classroom.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 8 Classroom
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
     content: Y'know, before I met you, I was never really an art guy.
@@ -39,7 +40,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: We didn't really talk at first, but I remember at one point, the teacher switched seats.
+    content: We didn't really talk at first, but I remember at one point, the teacher
+      switched seats.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Dialogue/Nathan Level/9 Cool Art.asset
+++ b/Assets/Dialogue/Nathan Level/9 Cool Art.asset
@@ -13,13 +13,16 @@ MonoBehaviour:
   m_Name: 9 Cool Art
   m_EditorClassIdentifier: 
   CPS: 30
+  SFXDirectory: Dialogue/nathan/multi
   entries:
   - avatar: {fileID: 0}
-    content: You'd always bring it into class, and everytime I looked over, you were always drawing something
+    content: You'd always bring it into class, and everytime I looked over, you were
+      always drawing something
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: I don't know how you were passing the class to be honest cause I definitely wasn't.
+    content: I don't know how you were passing the class to be honest cause I definitely
+      wasn't.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
@@ -32,7 +35,8 @@ MonoBehaviour:
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}
-    content: But I swear, your art, your characters, your little stories, it was all you'd ever wanna talk about.
+    content: But I swear, your art, your characters, your little stories, it was
+      all you'd ever wanna talk about.
     useCPS: 0
     CPS: 0
   - avatar: {fileID: 0}

--- a/Assets/Scripts/Dialogue/Dialogue.cs
+++ b/Assets/Scripts/Dialogue/Dialogue.cs
@@ -9,6 +9,7 @@ public class Dialogue : ScriptableObject
     [Header("Defaults")]
     [Range(0, 120)] [Tooltip("Set to 0 to disable typewriting effect")] 
     public int CPS = 30;
+    public string SFXDirectory = "";
 
     [Space(16)]
 

--- a/Assets/Scripts/Dialogue/DialogueAudio.cs
+++ b/Assets/Scripts/Dialogue/DialogueAudio.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class DialogueAudio : MonoBehaviour
 {
-    [SerializeField] string directory;
+    private string currDirectory;
     private AudioClip[] sounds;
     private AudioSource source;
     private AudioClip clip;
@@ -12,19 +13,40 @@ public class DialogueAudio : MonoBehaviour
 
     // Resources is a folder in Assets that's easy to access in code. To use the directory, just put the 
     // path to the folder of sounds you want to use from inside the resources folder.
-    void Start() {
+    void Start()
+    {
         source = GetComponent<AudioSource>();
-        sounds = Resources.LoadAll<AudioClip>(directory);
-        Random.seed = (int)System.DateTime.Now.Ticks;
+        UnityEngine.Random.seed = (int)System.DateTime.Now.Ticks;
     }
-    public void PlayDialogueSFX() {
-        if(!source.isPlaying) {
-            index = Random.Range(0, sounds.Length);
+
+    public void SetSFXDirectory(string directory)
+    {
+        if (directory != currDirectory)
+        {
+            try
+            {
+                currDirectory = directory;
+                sounds = Resources.LoadAll<AudioClip>(currDirectory);
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to load resources from {directory}: {e}");
+            }
+        }
+    }
+
+    public void Speak()
+    {
+        if (!source.isPlaying && sounds.Length > 0)
+        {
+            index = UnityEngine.Random.Range(0, sounds.Length);
             clip = sounds[index];
             source.PlayOneShot(clip);
-        }   
+        }
     }
-    public void Stop() {
+
+    public void WrapUp()
+    {
         source.Stop();
     }
 }

--- a/Assets/Scripts/Dialogue/DialogueSystem.cs
+++ b/Assets/Scripts/Dialogue/DialogueSystem.cs
@@ -88,6 +88,7 @@ public class DialogueSystem : MonoBehaviour
             // Update the textbox properties
             textbox.setAvatar(dialogueEntry.avatar);
             textbox.setText(dialogueEntry.content);
+            textbox.setSFXDirectory(dialogue.SFXDirectory);
             if (dialogueEntry.useCPS)   // If the dialogue entry uses custom CPS, use it.
                 textbox.setCPS(dialogueEntry.CPS);
             else                        // Otherwise, use the default CPS.

--- a/Assets/Scripts/Dialogue/Textbox.cs
+++ b/Assets/Scripts/Dialogue/Textbox.cs
@@ -17,16 +17,12 @@ public class Textbox : MonoBehaviour
     Sprite avatarSprite;
     string contentText;
     int CPS;
+    string sfxDirectory;
     bool sayRunning = false;
 
     int totalCharacters;
     int i;
 
-    void Update() {
-        if(sayRunning) {
-            speaker.PlayDialogueSFX();
-        }
-    }
     // Updates the avatar image to show
     public void setAvatar(Sprite avatar)
     {
@@ -43,6 +39,12 @@ public class Textbox : MonoBehaviour
     public void setCPS(int newCPS)
     {
         this.CPS = newCPS;
+    }
+
+    // Updates the dialogue SFX directory
+    public void setSFXDirectory(string newSFXDirectory)
+    {
+        this.sfxDirectory = newSFXDirectory;
     }
 
     // Clears the avatar image and content text
@@ -64,6 +66,10 @@ public class Textbox : MonoBehaviour
     public IEnumerator Say()
     {
         sayRunning = true;
+
+        // Set SFX path
+        speaker.SetSFXDirectory(sfxDirectory);
+
         // Hide the CTC indicator
         CTCAnimator.SetBool("Hidden", true);
 
@@ -97,6 +103,10 @@ public class Textbox : MonoBehaviour
             for (i = 0; i <= totalCharacters; i++)
             {
                 contentTMP.text = "<color=black>" + contentText.Substring(0, i) + "<color=white>" + contentText.Substring(i);
+
+                // Play SFX
+                speaker.Speak();
+                
                 yield return new WaitForSeconds(SPC);
             }
         }
@@ -106,6 +116,10 @@ public class Textbox : MonoBehaviour
 
         // Show the CTC indicator
         CTCAnimator.SetBool("Hidden", false);
+
+        // Wrap up any SFX
+        speaker.WrapUp();
+
         sayRunning = false;
     }
 


### PR DESCRIPTION
- Move sfxDirectory value to each dialogue object so dialogue speaker can be set with the correct directory every time
  - Reason: sfxDirectory is currently set via prefab instance override. we want to move away from that to make standardization easier
- Add error handling to sfx resource loading
- Make CPS attribute affect sfx speed 