### PR TITLE
fix bugs caused by scene entrance function called early

### DIFF
--- a/Assets/Scripts/Scene Loading/SceneLoader.cs
+++ b/Assets/Scripts/Scene Loading/SceneLoader.cs
@@ -101,10 +101,13 @@ public class SceneLoader : MonoBehaviour
         AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(index, LoadSceneMode.Single);
         asyncLoad.allowSceneActivation = false;
 
-        // Wait for the scene to finish loading before activating it
+        // Wait for the scene to finish loading
         yield return new WaitForSeconds(config.minLoadingTime);
         yield return new WaitUntil(() => asyncLoad.progress >= 0.9f);
+        
+        // Activate the scene
         asyncLoad.allowSceneActivation = true;
+        yield return new WaitUntil(() => asyncLoad.isDone);
     }
 
     private IEnumerator handleSceneEntrance()


### PR DESCRIPTION
- ensure scene loading is **completely** done by waiting for async operation isDone before completing the LoadAndEnterScene coroutine
  - this prevents the handleSceneEntrance couroutine from running early, causing these two bugs
    - pause menu being disabled in new scene
    - level selector being momentarily visible when entering new scene