### PR TITLE
improve player movement physics and orange object physics

### DIFF
--- a/Assets/Prefabs/Orange Object.prefab
+++ b/Assets/Prefabs/Orange Object.prefab
@@ -29,12 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8669401566246642394}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 37.847, y: 17.596, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &7949143088991643367
 SpriteRenderer:
@@ -47,6 +48,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -98,12 +100,18 @@ Rigidbody2D:
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
+  m_UseAutoMass: 1
+  m_Mass: 4.5775003
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 6200000, guid: be9f55ba61f4a45b2833211d464876b3, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 1
   m_SleepingMode: 1
   m_CollisionDetection: 1
@@ -116,8 +124,27 @@ PolygonCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8669401566246642394}
   m_Enabled: 1
-  m_Density: 1
+  m_Density: 10
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -152,6 +179,7 @@ PolygonCollider2D:
       - {x: 0.585, y: 0.57}
       - {x: 0.585, y: -0.57}
       - {x: -0.59499997, y: -0.57}
+  m_UseDelaunayMesh: 0
 --- !u!114 &156424493162379790
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Stickman.prefab
+++ b/Assets/Prefabs/Stickman.prefab
@@ -17,7 +17,6 @@ GameObject:
   - component: {fileID: 7165906262281608555}
   - component: {fileID: 2574978673430354921}
   - component: {fileID: 1450883229827684611}
-  - component: {fileID: 6249668290086506388}
   m_Layer: 8
   m_Name: Stickman
   m_TagString: Player
@@ -32,13 +31,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1450883229827684621}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3070488883831946263}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1450883229827684608
 MonoBehaviour:
@@ -53,21 +53,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animateSpawnOnLoad: 0
-  speed: 4
-  jumpForce: 6
-  movementSmoothing: 0.05
-  jumpBufferFramesMax: 5
+  speed: 4.25
+  jumpForce: 30
   ground:
     serializedVersion: 2
     m_Bits: 1088
   feetCollider: {fileID: 2574978673430354921}
   minY: -10
-  jumpAS: {fileID: 3999589686566454524}
-  deathAS: {fileID: 7989645283307328504}
-  SpawnAS: {fileID: 4335315624671786684}
+  jumpAudioSource: {fileID: 3999589686566454524}
+  footstepAudioSource: {fileID: 1089192759820579398}
+  deathAudioSource: {fileID: 7989645283307328504}
+  spawnAudioSource: {fileID: 4335315624671786684}
   respawner: {fileID: 0}
   respawnPos: {x: 0, y: 0, z: 0}
-  isPaused: 0
 --- !u!114 &1882610119951218810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -91,6 +89,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -148,6 +147,12 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 6200000, guid: c74e6d5387e77ed44ae0e32935a4f2ef, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 1
@@ -162,6 +167,25 @@ CapsuleCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 6200000, guid: c74e6d5387e77ed44ae0e32935a4f2ef, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -178,6 +202,25 @@ CircleCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 6200000, guid: e5b2587789da5d94583ca8a6aa43d80c, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -194,6 +237,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -212,7 +274,7 @@ BoxCollider2D:
   m_EdgeRadius: 0
 --- !u!95 &1450883229827684611
 Animator:
-  serializedVersion: 3
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -225,21 +287,55 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
---- !u!82 &6249668290086506388
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &3343981970825247549
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7880405190787127856}
+  - component: {fileID: 4335315624671786684}
+  m_Layer: 0
+  m_Name: Spawn Audio Source
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7880405190787127856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3343981970825247549}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3070488883831946263}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &4335315624671786684
 AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1450883229827684621}
+  m_GameObject: {fileID: 3343981970825247549}
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: -1643656973328474427, guid: f161f5ffa53013d40bd0c11e00ca8336, type: 2}
-  m_audioClip: {fileID: 8300000, guid: 13e20c2d37f825244a0836f8720151cd, type: 3}
+  m_audioClip: {fileID: 8300000, guid: 330dde176470e4599a6d7346cb2b1163, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
@@ -247,7 +343,7 @@ AudioSource:
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0
-  Priority: 131
+  Priority: 128
   DopplerLevel: 1
   MinDistance: 1
   MaxDistance: 500
@@ -325,7 +421,7 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!1 &3343981970825247549
+--- !u!1 &4210723780403577637
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -333,40 +429,41 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7880405190787127856}
-  - component: {fileID: 4335315624671786684}
+  - component: {fileID: 9041041960184236629}
+  - component: {fileID: 1089192759820579398}
   m_Layer: 0
-  m_Name: Spawn Audio Source
+  m_Name: Footsteps Audio Source
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7880405190787127856
+--- !u!4 &9041041960184236629
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3343981970825247549}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 4210723780403577637}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3070488883831946263}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!82 &4335315624671786684
+--- !u!82 &1089192759820579398
 AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3343981970825247549}
+  m_GameObject: {fileID: 4210723780403577637}
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: -1643656973328474427, guid: f161f5ffa53013d40bd0c11e00ca8336, type: 2}
-  m_audioClip: {fileID: 8300000, guid: 330dde176470e4599a6d7346cb2b1163, type: 3}
+  m_audioClip: {fileID: 8300000, guid: 13e20c2d37f825244a0836f8720151cd, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
@@ -374,7 +471,7 @@ AudioSource:
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0
-  Priority: 128
+  Priority: 131
   DopplerLevel: 1
   MinDistance: 1
   MaxDistance: 500
@@ -476,12 +573,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6737032821646560333}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3070488883831946263}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &7989645283307328504
 AudioSource:
@@ -603,12 +701,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7236936392782386149}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3070488883831946263}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &3999589686566454524
 AudioSource:
@@ -729,13 +828,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8253605663202983315}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 9041041960184236629}
   - {fileID: 2121598716726238685}
   - {fileID: 2706643437843351699}
   - {fileID: 7880405190787127856}
   m_Father: {fileID: 1450883229827684623}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -8,53 +8,56 @@ public class PlayerMovement : MonoBehaviour
     // Configuration parameters
     [SerializeField] private bool animateSpawnOnLoad = false;
 
-    [Header("Movement")] [SerializeField] private float speed;
-    [SerializeField] private float jumpForce;
-    [SerializeField] private float movementSmoothing = 0.05f;
-    [SerializeField] private int jumpBufferFramesMax = 5;
-    private float SFXDelay = 0.09f;
+    [Header("Movement")]
+    [SerializeField] private float speed = 4.25f;
+    [SerializeField] private float jumpForce = 30f;
+    [SerializeField] private float deferredJumpDelay = 0.1f;
+    [SerializeField] private float coyoteJumpDelay = 0.1f;
 
-
-    [Header("Ground Check")] [SerializeField]
-    private LayerMask ground;
-
+    [Header("Ground Check")]
+    [SerializeField] private LayerMask ground;
     [SerializeField] private Collider2D feetCollider;
 
-    [Header("Auto Respawn")] [SerializeField]
-    private float minY = -20f;
+    [Header("Auto Respawn")]
+    [SerializeField] private float minY = -20f;
+
+    [Header("Audio Sources")]
+    // Audio sources
+    [SerializeField] private AudioSource jumpAudioSource;
+    [SerializeField] private AudioSource footstepAudioSource;
+    [SerializeField] private AudioSource deathAudioSource;
+    [SerializeField] private AudioSource spawnAudioSource;
 
     // Cached components
     private Rigidbody2D rb2d;
     private Animator anim;
-    private AudioSource footstepAS;
-    [SerializeField] private AudioSource jumpAS;
-    [SerializeField] private AudioSource deathAS;
-    [SerializeField] private AudioSource SpawnAS;
-    // State variables
 
+    // State variables
+    private float SFXDelay = 0.09f;
     private float curSFXDelay;
     public RespawnManager respawner;
     public Vector3 respawnPos;
-    private Vector3 prevPos;
-
     private bool isDead = false;
-    [SerializeField] private bool isPaused = false;
+    private bool isPaused = false;
 
     // Input variables
     private bool jumpRequested = false;
-    private int jumpBufferFrames = 0;
-    private float horizontal;
+    private float horizontal = 0f;
+    private float lastGroundContactTime = 0f;
+    private float lastJumpRequestedTime = 0f;
 
     private void Awake()
     {
         // Get components
-        footstepAS = GetComponent<AudioSource>();
         rb2d = GetComponent<Rigidbody2D>();
         anim = GetComponent<Animator>();
         respawner = FindObjectOfType<RespawnManager>();
+
         // Set initial respawn position
-        prevPos = respawnPos = transform.position;
-        if (animateSpawnOnLoad) {
+        SetRespawnPos(transform.position);
+
+        if (animateSpawnOnLoad)
+        {
             rb2d.simulated = false;
             Spawn();
         }
@@ -62,10 +65,7 @@ public class PlayerMovement : MonoBehaviour
 
     private void Update()
     {
-        if (isDead)
-        {
-            return;
-        }
+        if (isDead) return;
 
         if (isPaused)
         {
@@ -83,7 +83,7 @@ public class PlayerMovement : MonoBehaviour
         if (transform.position.y < minY)
             Die();
 
-        anim.SetBool("Moving", (transform.position.x - prevPos.x) != 0 && horizontal != 0);
+        anim.SetBool("Moving", rb2d.velocity.x != 0 && horizontal != 0);
         anim.SetFloat("YVelocity", rb2d.velocity.y);
     }
 
@@ -93,39 +93,33 @@ public class PlayerMovement : MonoBehaviour
 
         Walk();
 
-        if (feetCollider.IsTouchingLayers(ground))
-            anim.SetBool("isTouchingGround", true);
-        else
-            anim.SetBool("isTouchingGround", false);
+        // Check if the player is currently touching the ground
+        bool isTouchingGround = feetCollider.IsTouchingLayers(ground);
+        anim.SetBool("isTouchingGround", isTouchingGround);
 
-        if (jumpRequested)
+        // Get the last time the values are true.
+        // We will use this for jump deferring and coyote jump
+        if (isTouchingGround) lastGroundContactTime = Time.time;
+        if (jumpRequested) lastJumpRequestedTime = Time.time;
+        jumpRequested = false;
+
+        bool recentlyContactedGround = (Time.time - lastGroundContactTime) < deferredJumpDelay;
+        bool recentlyRequestedJump = (Time.time - lastJumpRequestedTime) < coyoteJumpDelay;
+
+        bool shouldJumpNow = recentlyContactedGround && recentlyRequestedJump;
+        if (shouldJumpNow)
         {
-            if (feetCollider.IsTouchingLayers(ground))
-            {
-                Jump();
-                jumpAS.Play();
-                anim.SetTrigger("Jump");
-                jumpRequested = false;
-            }
-            else
-            {
-                jumpBufferFrames--;
-                if (jumpBufferFrames < 0)
-                    jumpRequested = false;
-            }
+            lastGroundContactTime = -1f;
+            lastJumpRequestedTime = -1f;
+            Jump();
         }
-        prevPos = transform.position;
     }
 
     private void GetInput()
     {
         horizontal = Input.GetAxisRaw("Horizontal");
-        if(horizontal == 0) footstepAS.Stop();
-        if (Input.GetButtonDown("Jump"))
-        {
-            jumpRequested = true;
-            jumpBufferFrames = jumpBufferFramesMax;
-        }
+        if (Input.GetButtonDown("Jump")) jumpRequested = true;
+        if (horizontal == 0) footstepAudioSource.Stop();
     }
 
     private void UpdateSpriteDirection()
@@ -140,7 +134,6 @@ public class PlayerMovement : MonoBehaviour
     {
         Debug.Log($"[PlayerMovement] Pause: {isPaused}");
         if (isPaused) transform.parent = null;
-
         rb2d.velocity = Vector2.zero;
         isPaused = !isPaused;
     }
@@ -150,25 +143,39 @@ public class PlayerMovement : MonoBehaviour
         // The SFXDelay stuff is added so that it will only play sounds after the player
         // has been walking for a certaint amount of time, just so things like
         // walking up stairs doesnt spam a bunch of short audio clips.
-        rb2d.velocity = new Vector2(horizontal * speed, rb2d.velocity.y);
+        float targetVelocity = horizontal * speed;
+        float velocityDiff = targetVelocity - rb2d.velocity.x;
+        float movement = Mathf.Pow(Mathf.Abs(velocityDiff), 2) * Mathf.Sign(velocityDiff);
+        rb2d.AddForce(movement * Vector2.right, ForceMode2D.Impulse);
+
         // The basic audio logic is: if not on ground, then stop footsteps.
-        // If velocity isn't 0 and right now we aren't playing sound, then play a sound.
-        if(!feetCollider.IsTouchingLayers(ground)) {
-            footstepAS.Stop();
+        // If velocity isn't 0 and right now we are9.n't playing sound, then play a sound.
+        if (!feetCollider.IsTouchingLayers(ground))
+        {
+            footstepAudioSource.Stop();
             curSFXDelay = SFXDelay;
-        } else if((anim.GetBool("Moving")) && !footstepAS.isPlaying) {
-            if(curSFXDelay > 0) {
+        }
+        else if ((anim.GetBool("Moving")) && !footstepAudioSource.isPlaying)
+        {
+            if (curSFXDelay > 0)
+            {
                 curSFXDelay -= Time.deltaTime;
-            } else {
-                footstepAS.Play();
+            }
+            else
+            {
+                footstepAudioSource.Play();
                 curSFXDelay = SFXDelay;
-            }   
+            }
         }
     }
 
     private void Jump()
     {
-        rb2d.velocity = new Vector2(rb2d.velocity.x, jumpForce);
+        rb2d.velocity = new Vector2(rb2d.velocity.x, 0);
+        rb2d.AddForce(jumpForce * Vector2.up, ForceMode2D.Impulse);
+
+        anim.SetTrigger("Jump");
+        jumpAudioSource.Play();
     }
 
     public void SetRespawnPos(Vector3 respawnPos)
@@ -179,13 +186,13 @@ public class PlayerMovement : MonoBehaviour
     public void Die()
     {
         if (isDead) return;
-        
+
         isDead = true;
-        
+
         // Freeze the player
         rb2d.simulated = false;
-        footstepAS.Stop();
-        deathAS.Play();
+        footstepAudioSource.Stop();
+        deathAudioSource.Play();
 
         // Trigger death animation
         anim.SetTrigger("Dead");
@@ -195,8 +202,8 @@ public class PlayerMovement : MonoBehaviour
     {
         anim.SetTrigger("Spawn");
     }
-    // Code to check if the player position is inside of another collider 
 
+    // Code to check if the player position is inside of another collider 
     IEnumerator Respawn()
     {
         yield return new WaitForSeconds(1f);
@@ -205,14 +212,17 @@ public class PlayerMovement : MonoBehaviour
         rb2d.simulated = true;
         rb2d.velocity = Vector2.zero;
 
-        respawner?.StartObjectRespawn();    
+        respawner?.StartObjectRespawn();
+
         // Move the player to the respawn position
-        SpawnAS.Play();
+        spawnAudioSource.Play();
         transform.position = respawnPos;
 
         isDead = false;
     }
-    public void setCanMove(int isOne) {
+
+    public void setCanMove(int isOne)
+    {
         rb2d.simulated = (isOne == 1);
     }
 }

--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -124,7 +124,6 @@ public class SteamManager : MonoBehaviour {
 		m_bInitialized = SteamAPI.Init();
 		if (!m_bInitialized) {
 			Debug.LogError("[Steamworks.NET] SteamAPI_Init() failed", this);
-
 			return;
 		}
 

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 6
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -44,13 +44,5 @@ Physics2DSettings:
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0
-  m_AlwaysShowColliders: 0
-  m_ShowColliderSleep: 1
-  m_ShowColliderContacts: 0
-  m_ShowColliderAABB: 0
-  m_ContactArrowScale: 0.2
-  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
-  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
-  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
-  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
+  m_GizmoOptions: 10
   m_LayerCollisionMatrix: dfbdfeffdfbdfeffdfbdfeffffffffffdfadfeff88a8feffdfadfeffffa9feffdfadfeff08f8ffff5fadfeffffffffff0fbafeffffffffff08aafeffffffffff08aaffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
- PlayerMovement.cs
  - instead of setting velocity for player movement, use AddForce()
    - this way, the player movement will work better with unity's physics engine and other physics interactable objects in the game 
  - refactor/improve player movement code
  - implement coyote jump
- use automass and density for orange objects