### PR TITLE
clear game save when build indices don't match

### DIFF
--- a/Assets/Scenes/Levels/Tutorial.unity
+++ b/Assets/Scenes/Levels/Tutorial.unity
@@ -877,10 +877,9 @@ Transform:
   - {fileID: 653319221}
   - {fileID: 774664987}
   - {fileID: 2025031238}
+  - {fileID: 1045072655}
   - {fileID: 1747390178}
   - {fileID: 2517903423726421872}
-  - {fileID: 1311323855}
-  - {fileID: 1516408220}
   m_Father: {fileID: 62498744}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1032651917
@@ -914,6 +913,68 @@ Transform:
   m_Children: []
   m_Father: {fileID: 653319221}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1045072654
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1027297668}
+    m_Modifications:
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.439804
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366584036624076156, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+      propertyPath: m_Name
+      value: Pit Enemy 2.25x
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+--- !u!4 &1045072655 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8366584036624076153, guid: 509efcf5592a6e24ba78a43ef0fa9df6, type: 3}
+  m_PrefabInstance: {fileID: 1045072654}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1052394897
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1064,80 +1125,6 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1450883229827684623, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
   m_PrefabInstance: {fileID: 1256590537236634894}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1311323854
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1027297668}
-    m_Modifications:
-    - target: {fileID: 5014702933489592528, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: respawn
-      value: 
-      objectReference: {fileID: 1776557252}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 46.819176
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.4178371
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592532, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_Name
-      value: Pit Enemy (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
---- !u!4 &1311323855 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-  m_PrefabInstance: {fileID: 1311323854}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1315380763
 PrefabInstance:
@@ -1473,80 +1460,6 @@ PrefabInstance:
       addedObject: {fileID: 301474636}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bc63ea0ba70946a4a8a8c7437f40a8b8, type: 3}
---- !u!1001 &1516408219
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1027297668}
-    m_Modifications:
-    - target: {fileID: 5014702933489592528, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: respawn
-      value: 
-      objectReference: {fileID: 1776557252}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 50.249172
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.307837
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5014702933489592532, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-      propertyPath: m_Name
-      value: Pit Enemy (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
---- !u!4 &1516408220 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
-  m_PrefabInstance: {fileID: 1516408219}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1521747328
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Saving and Loading/GameManager.cs
+++ b/Assets/Scripts/Saving and Loading/GameManager.cs
@@ -36,6 +36,8 @@ public class GameManager : MonoBehaviour
         serializer = new ObjectSerializer<GameData>();
         gameData = null;
 
+        SceneManager.sceneLoaded += OnSceneLoaded;
+
         // Call the Save function when the game quits
         Application.quitting += Save;
     }
@@ -133,5 +135,21 @@ public class GameManager : MonoBehaviour
     public bool CanLoad()
     {
         return serializer.CanRead(saveFilePath);
+    }
+
+    // Action for when a new scene is loaded.
+    // If the new scene doesn't match the scene for the save file, clear the cached save.
+    public void OnSceneLoaded(Scene scene, LoadSceneMode _) {
+        // If no cached save file, there's nothing to clear
+        if (gameData == null) return;
+
+        // Check if the build indices match
+        int loadedSceneIndex = scene.buildIndex;
+        bool loadedSaveBuildIndexFound = Global.LevelToBuildIndexMap.TryGetValue(gameData.level, out int loadedSaveBuildIndex);
+        bool currentGameDataIsValid = loadedSaveBuildIndexFound && (loadedSceneIndex == loadedSaveBuildIndex);
+        if (!currentGameDataIsValid) {
+            gameData = null;
+            Debug.Log($"[GameManager] The loaded scene ({loadedSceneIndex}) didn't match the saved scene ({loadedSaveBuildIndex}). Cleared the cached game save.");
+        }
     }
 }

--- a/Assets/Scripts/Saving and Loading/Serializable Data Objects/CheckpointData.cs
+++ b/Assets/Scripts/Saving and Loading/Serializable Data Objects/CheckpointData.cs
@@ -58,17 +58,16 @@ public class CheckpointData : MonoBehaviour
 
         // Ensure build index matches before using the loaded gameData
         bool buildIndexMatch = savedBuildIndex == SceneManager.GetActiveScene().buildIndex;
-        if (buildIndexMatch)
-        {
-            List<SerializableCheckpointData> allCheckpointData = gameManager?.gameData?.checkpointData;
-            SerializableCheckpointData checkpointData = allCheckpointData?.Find(x => x.ID == ID);
+        if (!buildIndexMatch) return;
 
-            // Ensure checkpoint data exists
-            if (checkpointData == null)
-                Debug.LogWarning("[CheckpointData] Checkpoint data not found for checkpoint " + ID);
-            else if (checkpointData.isActivated)
-                checkpoint.Activate();
-        }
+        // Ensure checkpoint data exists
+        List<SerializableCheckpointData> allCheckpointData = gameManager?.gameData?.checkpointData;
+        SerializableCheckpointData checkpointData = allCheckpointData?.Find(x => x.ID == ID);
+
+        if (checkpointData == null)
+            Debug.LogWarning("[CheckpointData] Checkpoint data not found for checkpoint " + ID);
+        else if (checkpointData.isActivated)
+            checkpoint.Activate();
     }
 
     // Returns a serializable version of the player's data

--- a/Assets/Scripts/Saving and Loading/Serializable Data Objects/CutsceneData.cs
+++ b/Assets/Scripts/Saving and Loading/Serializable Data Objects/CutsceneData.cs
@@ -64,21 +64,19 @@ public class CutsceneData : MonoBehaviour
 
         // Ensure build index matches before using the loaded gameData
         bool buildIndexMatch = savedBuildIndex == SceneManager.GetActiveScene().buildIndex;
-        if (buildIndexMatch)
+        if (!buildIndexMatch) return;
+
+        // Ensure cutscene data exists
+        List<SerializableCutsceneData> allCutsceneData = gameData?.cutsceneData;
+        SerializableCutsceneData cutsceneData = allCutsceneData?.Find(x => x.ID == ID);
+
+        if (cutsceneData == null)
+            Debug.LogWarning($"[CutsceneData] Cutscene data not found for cutscene {ID}", gameObject);
+        else if (cutsceneData.hasPlayed)
         {
-            List<SerializableCutsceneData> allCutsceneData = gameData?.cutsceneData;
-            SerializableCutsceneData cutsceneData = allCutsceneData?.Find(x => x.ID == ID);
-
-            // Ensure cutscene data exists
-            if (cutsceneData == null)
-                Debug.LogWarning($"[CutsceneData] Cutscene data not found for cutscene {ID}", gameObject);
-            else if (cutsceneData.hasPlayed)
-            {
-                cutsceneTrigger.hasPlayed = true;
-                cutsceneTrigger.GoToEndState();
-            }
+            cutsceneTrigger.hasPlayed = true;
+            cutsceneTrigger.GoToEndState();
         }
-
     }
 
     // Returns a serializable version of the player's data

--- a/Assets/Scripts/Saving and Loading/Serializable Data Objects/PlayerData.cs
+++ b/Assets/Scripts/Saving and Loading/Serializable Data Objects/PlayerData.cs
@@ -46,23 +46,22 @@ public class PlayerData : MonoBehaviour
         
         // Ensure build index matches before using the loaded gameData
         bool buildIndexMatch = savedBuildIndex == SceneManager.GetActiveScene().buildIndex;
-        if (buildIndexMatch)
+        if (!buildIndexMatch) return;
+        
+        // Ensure player data exists 
+        SerializablePlayerData playerData = gameData?.playerData;
+        if (playerData != null)
         {
-            // Ensure player data exists 
-            SerializablePlayerData playerData = gameData?.playerData;
-            if (playerData != null)
-            {
-                transform.position = new Vector3(
-                    playerData.position[0],
-                    playerData.position[1],
-                    playerData.position[2]
-                );
-                playerMovement.respawnPos = new Vector3(
-                    playerData.respawnPos[0],
-                    playerData.respawnPos[1],
-                    playerData.respawnPos[2]
-                );
-            }
+            transform.position = new Vector3(
+                playerData.position[0],
+                playerData.position[1],
+                playerData.position[2]
+            );
+            playerMovement.respawnPos = new Vector3(
+                playerData.respawnPos[0],
+                playerData.respawnPos[1],
+                playerData.respawnPos[2]
+            );
         }
     }
 


### PR DESCRIPTION
- add logic to clear the cached game save once the loaded scene doesn't match the load file's scene anymore
  - this basically fixes the issue where if a player has a game save for a given scene/level and choose the level from the level selector menu, but instead of bringing the player to the beginning, the existing logic loads the game save (as if they clicked "resume")