### PR TITLE
update the sprite rendering order for the level grounds

### DIFF
--- a/Assets/Prefabs/Ground Pieces/Chase Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Chase Ground.prefab
@@ -70,8 +70,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 263e469f177a7a5409ac641ab0e72634, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -154,8 +154,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 263e469f177a7a5409ac641ab0e72634, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -539,8 +539,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 263e469f177a7a5409ac641ab0e72634, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -623,8 +623,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5e2413032a4993948a70c85043369a73, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -707,8 +707,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: fcfdab6381fa6f44ba2d8663de36e90c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Claire Part 1 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Claire Part 1 Ground.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1294248809256463342}
   - component: {fileID: 6579987004786240038}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: flower-1 (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -70,8 +70,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d220e5309cbff14d904db94557c34da, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -94,7 +94,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2240391631465729576}
   - component: {fileID: 1116043338716057004}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse8
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -154,8 +154,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 758cdeb9968651f4797f65e5c10886f4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -178,7 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1345505417103918912}
   - component: {fileID: 574663427827396227}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: ClairePetNames
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -238,8 +238,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 68e4a23f2963ccd429bc91cbf9ea514a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -262,7 +262,7 @@ GameObject:
   m_Component:
   - component: {fileID: 835868339926507975}
   - component: {fileID: 6996593592494942750}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: AmericanFlag
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -322,8 +322,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ee2eda1b1f9b17d4da60252603dc54c1, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -346,7 +346,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1931855325375341417}
   - component: {fileID: 7884056990356502400}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Bee (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -406,8 +406,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7cf73f1315b71cd438bda7ec36eb1122, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -430,7 +430,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7982890276597572668}
   - component: {fileID: 3523941001109298509}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Beach
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -490,8 +490,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: a1ef80f6e72f29543b3d251769c24c6f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -514,7 +514,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1981385801405686678}
   - component: {fileID: 656351012147121732}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Renaissance Faire To DO
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -574,8 +574,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: a294c3c0a8cdd644e9a4308adb429e3f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -598,7 +598,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4537338310628071315}
   - component: {fileID: 8616673780920101524}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Quadratic Formula
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -658,8 +658,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 73e0ad86b8aadc6439387d10f2c9ea6b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -682,7 +682,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6965076958831172644}
   - component: {fileID: 6557609037229446536}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: BucketList
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -742,8 +742,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e842f04540dd8e84bbe0605377fac593, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -766,7 +766,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2098658416040545898}
   - component: {fileID: 2210723283775511565}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Bee
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -826,8 +826,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7cf73f1315b71cd438bda7ec36eb1122, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -850,7 +850,7 @@ GameObject:
   m_Component:
   - component: {fileID: 181862977846052559}
   - component: {fileID: 755046468279968771}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: flower-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -910,8 +910,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d220e5309cbff14d904db94557c34da, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -934,7 +934,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8029110159999438766}
   - component: {fileID: 2871253869562332106}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: ClaireBookReccs
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -994,8 +994,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 1dac2d175d6cc61439b2048b9ff9ced2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1076,7 +1076,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8837288108809973862}
   - component: {fileID: 4558165844770494532}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: BritishFlag
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1136,8 +1136,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 4bfff77ccff458c4ba1df066fe4a28c8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1160,7 +1160,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1380426002024090630}
   - component: {fileID: 4521562517504604667}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bench 1_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1220,8 +1220,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 5051237294693598688, guid: 190ed1a3c13abb546a91585fdfde910f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1244,7 +1244,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4592297438816890928}
   - component: {fileID: 3268719930049871663}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: MathTable
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1304,8 +1304,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5a9e261a5d871564185fc4667f796844, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1328,7 +1328,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8308430689128922565}
   - component: {fileID: 642960061322024304}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bush 2_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1388,8 +1388,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 8931794057646554146, guid: f6b921743e78a3c4c89d00ac98f1e5d8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1412,7 +1412,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3303510782249904846}
   - component: {fileID: 1468612730269795277}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Cat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1472,8 +1472,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5ff13bc03418670438ce4d0acdcc68b9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1496,7 +1496,7 @@ GameObject:
   m_Component:
   - component: {fileID: 129820269794352410}
   - component: {fileID: 5630672969043765061}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Carnival
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1556,8 +1556,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f438541f119002b469a2cd9e96aca6e2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1580,7 +1580,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8649639562164133043}
   - component: {fileID: 8193425596734479506}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Bear
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1640,8 +1640,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 50fbc20253b08af41b11066bba0ab88a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1664,7 +1664,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6740937717925782510}
   - component: {fileID: 5327572377033438762}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Camping
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1724,8 +1724,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: c7a22004786b7084aa8bc3288b9b296c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1748,7 +1748,7 @@ GameObject:
   m_Component:
   - component: {fileID: 186202800776322489}
   - component: {fileID: 61522121423475604}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: ZodiacSigns
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1808,8 +1808,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: bcb5c96956ea5244a8a7245400bebcf1, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1832,7 +1832,7 @@ GameObject:
   m_Component:
   - component: {fileID: 997916028738893151}
   - component: {fileID: 5650754870631436627}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1892,8 +1892,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e1e35a049f6fab34ebf654823bdf0a9c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2111,8 +2111,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 48751b1faf934eb49a79317510872e4a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2195,8 +2195,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: a4687ee7a5ef3a8489561584ba654cb3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2286,7 +2286,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9104034591230632416}
   - component: {fileID: 1148454624159826210}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Beehive
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2346,8 +2346,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0bb76e000dbd7f8469a1d05ec305c1e6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2370,7 +2370,7 @@ GameObject:
   m_Component:
   - component: {fileID: 449588794690640445}
   - component: {fileID: 7183588880151067145}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2430,8 +2430,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ecaddc6887ad1a74d8590aea29c3b161, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2454,7 +2454,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6779653936672150194}
   - component: {fileID: 375038423412012447}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bush 2_0 (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2514,8 +2514,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 8931794057646554146, guid: f6b921743e78a3c4c89d00ac98f1e5d8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2538,7 +2538,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2224773259440993055}
   - component: {fileID: 4434143348802161577}
-  m_Layer: 5
+  m_Layer: 16
   m_Name: Rat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2598,8 +2598,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: befe33c58137981489249a5d08ef1100, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2622,7 +2622,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1041787932553082718}
   - component: {fileID: 8821876611329937396}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: GiftRemidners
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2682,8 +2682,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 2bca2beaf00033944b25f57c26111477, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Claire Part 2 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Claire Part 2 Ground.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7245818512776559681}
   - component: {fileID: 2362369457596151263}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -70,8 +70,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -94,7 +94,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7049745052100037946}
   - component: {fileID: 6611728460463456594}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -154,8 +154,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -178,7 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8350124901535185494}
   - component: {fileID: 45120141533288139}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Frog
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -238,8 +238,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f6d4087e80a88874e953f1966cc87b96, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -262,7 +262,7 @@ GameObject:
   m_Component:
   - component: {fileID: 368442456375460989}
   - component: {fileID: 6940415191643651585}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Eye
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -322,8 +322,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: af2bd9500594ade4688503c1048d5f7a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -346,7 +346,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3385205885392552100}
   - component: {fileID: 4786854327349551280}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -406,8 +406,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -430,7 +430,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6911253267499088056}
   - component: {fileID: 2610005842635029652}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bowling
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -490,8 +490,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 603b9c1fea278c74c8a9d0ea19b09f19, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -514,7 +514,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4793740012551030911}
   - component: {fileID: 2558946448028100151}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -574,8 +574,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -598,7 +598,7 @@ GameObject:
   m_Component:
   - component: {fileID: 445551685357068322}
   - component: {fileID: 7196078911938156884}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -658,8 +658,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -682,7 +682,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2130423125684251187}
   - component: {fileID: 8883814506050689753}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -742,8 +742,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -766,7 +766,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5946879198670123251}
   - component: {fileID: 9058971059014425947}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -826,8 +826,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -850,7 +850,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4004794977108260969}
   - component: {fileID: 4899618027457991077}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SwirlSquare
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -910,8 +910,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7d00067f33b071f4288bb9e71c3be4b0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -934,7 +934,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4941896530569525797}
   - component: {fileID: 6195856440378917028}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: FatSquirrel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -994,8 +994,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 327dec91d201f6848adb1a4ea43b43c5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1018,7 +1018,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5649737841315580995}
   - component: {fileID: 8816690310862906113}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1078,8 +1078,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1102,7 +1102,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8334454284755227265}
   - component: {fileID: 9036580405634180696}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Renaissance Faire Outfit List
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1162,8 +1162,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 73c58250396e0a54d8f43326a49ff7c5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1186,7 +1186,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3022620631275834310}
   - component: {fileID: 2602280750216912815}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1246,8 +1246,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 6c09130add8245f49bcd7c27a46a791d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1270,7 +1270,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8552742423472874867}
   - component: {fileID: 6122055503744361686}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1330,8 +1330,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1594,8 +1594,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 830eaa45042c39144b55874ec6c7eb2b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1711,8 +1711,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: eaec37dce6672794ab0f19edb0c654bd, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1735,7 +1735,7 @@ GameObject:
   m_Component:
   - component: {fileID: 626202013092379345}
   - component: {fileID: 2190501647662174900}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1795,8 +1795,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1819,7 +1819,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6901031118032715154}
   - component: {fileID: 6516193201306284401}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Raincloud
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1879,8 +1879,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 518d383329f4a6b48842b7b1c4b4f319, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1903,7 +1903,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6292084615658274236}
   - component: {fileID: 5586153347593727876}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1963,8 +1963,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ed00e403a08e1894cb8ea2be5a86c592, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1987,7 +1987,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8547275398807488389}
   - component: {fileID: 5812470490864351990}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2047,8 +2047,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2071,7 +2071,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8909661568142558619}
   - component: {fileID: 5532452163367372071}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SwirlSquare (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2131,8 +2131,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7d00067f33b071f4288bb9e71c3be4b0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2155,7 +2155,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9200703307610056404}
   - component: {fileID: 5311743063977650039}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bee
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2215,8 +2215,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7cf73f1315b71cd438bda7ec36eb1122, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2239,7 +2239,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8775822095033826440}
   - component: {fileID: 712002590263965898}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2299,8 +2299,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2323,7 +2323,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6630322392259851486}
   - component: {fileID: 2287657142228250327}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Cat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2383,8 +2383,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5ff13bc03418670438ce4d0acdcc68b9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2407,7 +2407,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3033051008461854156}
   - component: {fileID: 3260033722535239622}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2467,8 +2467,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2491,7 +2491,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2025822965344468631}
   - component: {fileID: 7619219590660032658}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2551,8 +2551,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2575,7 +2575,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8261769934880839156}
   - component: {fileID: 25953474563494320}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2635,8 +2635,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2659,7 +2659,7 @@ GameObject:
   m_Component:
   - component: {fileID: 931087906977541104}
   - component: {fileID: 2403470328385420941}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2719,8 +2719,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2743,7 +2743,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4363253969973142502}
   - component: {fileID: 5862210978673150239}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MathProblem3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2803,8 +2803,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3c24511fe0c88a845a9ff28e60cbfb84, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2827,7 +2827,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8100840955742284528}
   - component: {fileID: 3968227688824665055}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2887,8 +2887,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2911,7 +2911,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2375351397569971097}
   - component: {fileID: 4374775287851721006}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SupermanS
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2971,8 +2971,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 256a6cdfead8da04995297d28a53c5b4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2995,7 +2995,7 @@ GameObject:
   m_Component:
   - component: {fileID: 668605165048325136}
   - component: {fileID: 3233917732239165494}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3055,8 +3055,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3079,7 +3079,7 @@ GameObject:
   m_Component:
   - component: {fileID: 198724916826633668}
   - component: {fileID: 6949506942819294665}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3139,8 +3139,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3163,7 +3163,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7704972236790345140}
   - component: {fileID: 7968351502547771471}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MikeWorkout
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3223,8 +3223,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 06212b7d57053e94e9ee0b285300bd61, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3247,7 +3247,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9105473097957969125}
   - component: {fileID: 61415551249303646}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3307,8 +3307,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3331,7 +3331,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4488160435607127628}
   - component: {fileID: 4410687561357175584}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: BookNotes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3391,8 +3391,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 6d2943f4e1fc10948b8f052ba89ff8b6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3415,7 +3415,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2288921157594397896}
   - component: {fileID: 1768638782061650882}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3475,8 +3475,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 8147d36a43c5a684c8bf45bf1ad90b70, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3568,7 +3568,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3380276671981909253}
   - component: {fileID: 6613444415655029029}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Swirl (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3628,8 +3628,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b8eddc270abbb44489028f2a198effc9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Mike Part 1 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Mike Part 1 Ground.prefab
@@ -44,7 +44,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3819257354648153353}
   - component: {fileID: 6481888739951218707}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: FastBird
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -104,8 +104,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 65bf2ac11d5b7864886eda512ed2fec9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -128,7 +128,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8405514698881236652}
   - component: {fileID: 7499542279092528372}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Carnival Prize
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -188,8 +188,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 2fa49391465d29d44a750a0b6348018b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -212,7 +212,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3341560429541238784}
   - component: {fileID: 6739868982177184855}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse9
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -272,8 +272,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 9617bfe238ec342488f1efd4ff5e7e05, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -296,7 +296,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7018390529458993151}
   - component: {fileID: 4300524153231495444}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse10 (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -356,8 +356,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d96422b093fdac04ea89b8667fdd8e62, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -380,7 +380,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8147462356476408174}
   - component: {fileID: 2648979491104994011}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Quiz Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -440,8 +440,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 50c24306c133b344998f510e46eeaa49, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -464,7 +464,7 @@ GameObject:
   m_Component:
   - component: {fileID: 11164563542205180}
   - component: {fileID: 3837428876194389033}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: TicTacToe
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -524,8 +524,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f875b3de708705742bc8c4e50d152880, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -548,7 +548,7 @@ GameObject:
   m_Component:
   - component: {fileID: 715615925987547333}
   - component: {fileID: 3467182706964010154}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bring Book For Class Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -608,8 +608,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 78722cadc61de464591c477a0bdf6ddb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -632,7 +632,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1359958856878399338}
   - component: {fileID: 8481940565333923083}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse10
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -692,8 +692,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d96422b093fdac04ea89b8667fdd8e62, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -716,7 +716,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4873388608193374876}
   - component: {fileID: 6290952937771909667}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Cat (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -776,8 +776,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5ff13bc03418670438ce4d0acdcc68b9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -800,7 +800,7 @@ GameObject:
   m_Component:
   - component: {fileID: 808507957287480092}
   - component: {fileID: 8833600381500474593}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Dungeons and Dragons Meetup
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -860,8 +860,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 485fb312a0fa93f47901960ba4dc0ca3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -884,7 +884,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1982838496845920109}
   - component: {fileID: 3075359656065509338}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse11
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -944,8 +944,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: eba126514c5bd4d48af92b1335105740, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -968,7 +968,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5465553346447484036}
   - component: {fileID: 5184188210962690501}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Mental Health Counselor Appointment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1028,8 +1028,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 714d2f3b943d17d4b8f04832bd87b19f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1052,7 +1052,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4191370801636225976}
   - component: {fileID: 1592269257698576375}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MikeWrestlingTournamentTImes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1112,8 +1112,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: fe983b16841dd6144b7dd55cf8c41b10, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1136,7 +1136,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2862613189304113613}
   - component: {fileID: 3803688505606681505}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SuicideHotline
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1196,8 +1196,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: c977970ee3fec434eb371251e3e52776, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1220,7 +1220,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3971428661487152545}
   - component: {fileID: 6121223254196603197}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Stickman Art Account
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1280,8 +1280,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e054c920e916bba49b2b2de46de8811d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1304,7 +1304,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8375699092640414156}
   - component: {fileID: 1156427142059075387}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: FatSquirrel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1364,8 +1364,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 327dec91d201f6848adb1a4ea43b43c5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1388,7 +1388,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6381925334503126929}
   - component: {fileID: 7800810409438655637}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse7
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1448,8 +1448,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: c8d7a224d36d1f34e85f42efbad555e6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1472,7 +1472,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5885347769327458528}
   - component: {fileID: 8618571180191072786}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: GroupHousePlan
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1532,8 +1532,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d741e2238cffd1946861ae37d1a87618, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1623,7 +1623,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1799563086502836901}
   - component: {fileID: 4475117316561051438}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse11 (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1683,8 +1683,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: eba126514c5bd4d48af92b1335105740, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1707,7 +1707,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5518398584732030173}
   - component: {fileID: 1051884499433442602}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Mike Apple Pie Recipe
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1767,8 +1767,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e634de80937c31f459220be996f49917, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1791,7 +1791,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6839154357328050471}
   - component: {fileID: 4422880769299709324}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bunny
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1851,8 +1851,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b9448ecbf5b622347b2bea749a417a87, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1875,7 +1875,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5135302023581250568}
   - component: {fileID: 7036970044631543618}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Movies
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1935,8 +1935,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 9c74d7c171660314da7b5da4ff8a0bf7, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1959,7 +1959,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8210438471783498485}
   - component: {fileID: 8291806001350256419}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Renaissance Faire Costume Brainstorm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2019,8 +2019,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: c13ef55a2d1b8d64795b4bae897d8b1c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2043,7 +2043,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2627121942758701806}
   - component: {fileID: 2990196118563963200}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Return Library Book Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2103,8 +2103,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 778ad4c703cdf504a824d4b627db3b5b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2127,7 +2127,7 @@ GameObject:
   m_Component:
   - component: {fileID: 156508354023394294}
   - component: {fileID: 7566750824854679373}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: TV Shpws
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2187,8 +2187,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 407a4dfeb12eb8a42bfd17f6caa7aea4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2304,8 +2304,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 58f83de76037e9d44a6f3b53c2ca3c0f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2388,8 +2388,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 9a6c4f85379c8384c94932a80b9c688f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2679,7 +2679,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9159708781689145657}
   - component: {fileID: 3498071850563209340}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2739,8 +2739,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 4ae4f6e02b2fbae4bb349def95412f87, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2763,7 +2763,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4591108900409510723}
   - component: {fileID: 1666813235962186270}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: TipCalculate
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2823,8 +2823,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ee765923d87ed284e8afa369e1da9f5d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2847,7 +2847,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7452325107554298948}
   - component: {fileID: 2209810726473003893}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Pythagorean Theorem
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2907,8 +2907,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ac69c3942a6149d4b9c3a694cbcfcfe5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2931,7 +2931,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4890597304008440195}
   - component: {fileID: 7889459241626695535}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MorseCode
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2991,8 +2991,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 79b520d3daf7a8740bd33e5c0a980776, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3015,7 +3015,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3417313461370211921}
   - component: {fileID: 7598378539310046221}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: DrAppointment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3075,8 +3075,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 5fe3b4f28e2ebce42b27c0138d9f611e, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3099,7 +3099,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3020583350723277269}
   - component: {fileID: 1636588405498195793}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: IceCream
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3159,8 +3159,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 1af770dea54c6b746aeb0f69c03c0af2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3183,7 +3183,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1649776563416221534}
   - component: {fileID: 1341904812886058280}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: ToDoList
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3243,8 +3243,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 93c5a45ba9528974eb162eb76d78f72b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3267,7 +3267,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7609649602406147032}
   - component: {fileID: 7790114432271855884}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Test Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3327,8 +3327,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e2c8ad04f1448f34f866c553a7bbc1ac, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3351,7 +3351,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7706218747038974113}
   - component: {fileID: 1965687468966790795}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: ReminderList
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3411,8 +3411,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d842d1291fe603e49b0d770e760445a7, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3435,7 +3435,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4479819073449615727}
   - component: {fileID: 4248565490305346820}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Ice Cream
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3495,8 +3495,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d0adaf24df4dfc4b90eff90cf1dfcfe, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3519,7 +3519,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4985603653768947652}
   - component: {fileID: 3228688503507246809}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Car Driver Test Notes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3579,8 +3579,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 51db897398994614da9e2b19b8595127, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Mike Part 2 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Mike Part 2 Ground.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6470049343715132063}
   - component: {fileID: 6426808164582087496}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Birthday Idea for Stickman
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -70,8 +70,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 1e65b3036fe7733479d1c605052d9977, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -94,7 +94,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5638735336348380872}
   - component: {fileID: 6686882680821545222}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CardSuites
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -154,8 +154,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e3ecf74eff775e8498c7a5da244cac16, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -178,7 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3317299539638573082}
   - component: {fileID: 3717606097090780130}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Renaissance Faire Shield
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -238,8 +238,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 78411ddad8decfc4fbb5d8f2708e7672, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -355,8 +355,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3f2c66ec9045b01459c65b6eae1f25fd, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -744,8 +744,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 07420f643629441438263095ea0d72f7, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -768,7 +768,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8723712902279457371}
   - component: {fileID: 451245929425686870}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bring Book For Class Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -828,8 +828,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 78722cadc61de464591c477a0bdf6ddb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -852,7 +852,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1603364667470860008}
   - component: {fileID: 6283606641832898320}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Hair Dye Ideas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -912,8 +912,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 703e37545e3936140a07941205dd94e8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -936,7 +936,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1386736258549480195}
   - component: {fileID: 9033665797477520425}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Report Card Reminder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -996,8 +996,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 17778c55e44180f4ba825db318344255, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1020,7 +1020,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1776178131607329491}
   - component: {fileID: 3699390781356858123}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: FishTank
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1080,8 +1080,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: aec6f34027848d74698279ee45a3b11e, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1104,7 +1104,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2177467239596054978}
   - component: {fileID: 8303206236575749205}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Story Brainstorm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1164,8 +1164,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 57d18afcf7436a04f91453f2fab05377, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1188,7 +1188,7 @@ GameObject:
   m_Component:
   - component: {fileID: 789345630299084528}
   - component: {fileID: 6312112155963705482}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MathProblem4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1248,8 +1248,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: de72ca25092d74744b63a27a0a71b748, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1272,7 +1272,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5948926837585801297}
   - component: {fileID: 685678775985440246}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: PetList
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1332,8 +1332,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ca907b59b5da9e744a085909f2795335, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1356,7 +1356,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2304361456220511277}
   - component: {fileID: 6034273422328128293}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Minecraft Build Ideas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1416,8 +1416,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 6d30ead2feecb3040bea83e9b5131d69, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1440,7 +1440,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6110826133309809142}
   - component: {fileID: 8624258956295765285}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Plants
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1500,8 +1500,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: faf4e0a2007e9034898d6d479af1a3ae, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1558,7 +1558,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5375618366993984701}
   - component: {fileID: 6389195788904503694}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Car Drive Ideas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1618,8 +1618,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 8a67b53ccff5e0f42b823a74468d97c3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1642,7 +1642,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1517800536220618268}
   - component: {fileID: 7346121383948328493}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Story Character Brainstorm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1702,8 +1702,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 8ef17f57ca62a74478661d783974a9b6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1726,7 +1726,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8828913589110619224}
   - component: {fileID: 6145662073727060358}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Bee
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1786,8 +1786,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 7cf73f1315b71cd438bda7ec36eb1122, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1810,7 +1810,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5447517524129997935}
   - component: {fileID: 4487025074609768876}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: HangmanGame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1870,8 +1870,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 28e1d9e4ae8d7a846908559078ca8100, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1894,7 +1894,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2306725701535295219}
   - component: {fileID: 2694777979647475760}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: MathProblem3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1954,8 +1954,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3c24511fe0c88a845a9ff28e60cbfb84, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1978,7 +1978,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6854649321425775002}
   - component: {fileID: 8092723230345964760}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Sunglasses
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2038,8 +2038,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: bb821b976cff8384fba5f9af5bb9f510, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2062,7 +2062,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7126626987838614312}
   - component: {fileID: 690535864712751144}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Renaissance Faire Sword Idea
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2122,8 +2122,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e749135f0fd1e65448c2af441301eba6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2146,7 +2146,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6949984886711313543}
   - component: {fileID: 7478757016254374620}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Math HW Agenda List
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2206,8 +2206,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e97e4dec20c48e44cbb43b9c14d236e3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2230,7 +2230,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5521557324999416773}
   - component: {fileID: 4745840893185577155}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Car Repair Shop To Dos
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2290,8 +2290,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ef324aee6ad84824f97c9ec398f46c33, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2314,7 +2314,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3421886608960095725}
   - component: {fileID: 8340261065502601049}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Horse12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2374,8 +2374,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 4ae4f6e02b2fbae4bb349def95412f87, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2398,7 +2398,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5956907205732625771}
   - component: {fileID: 2141116170369251331}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SupermanS
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2458,8 +2458,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 256a6cdfead8da04995297d28a53c5b4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Mike Part 3 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Mike Part 3 Ground.prefab
@@ -135,8 +135,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 90f7c8ec8abcb764d89d1f462b79e08a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Ground Pieces/Nathan Part 1 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Nathan Part 1 Ground.prefab
@@ -23,14 +23,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5753865099657894941}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6496076140487724916}
   - {fileID: 6496076142013766817}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6496076140487724917
 GameObject:
@@ -55,14 +56,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6496076140487724917}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6496076140813921979}
   - {fileID: 6496076141837324479}
   m_Father: {fileID: 6647385477069904264}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6496076140813921980
 GameObject:
@@ -88,12 +90,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6496076140813921980}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6496076140487724916}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &6496076140813921978
 SpriteRenderer:
@@ -106,6 +109,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -132,8 +136,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: fbda060dd81fd40a19cd7e2955dc6437, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -170,12 +174,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6496076141837324448}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 100, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6496076140487724916}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &6496076141837324478
 SpriteRenderer:
@@ -188,6 +193,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -214,8 +220,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f94fbbadd334a4f7dbfe613a3d3bd63d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -253,14 +259,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6496076142013766818}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6051704370376709550}
   - {fileID: 6051704369510940857}
   m_Father: {fileID: 6647385477069904264}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &6496076142013766847
 Rigidbody2D:
@@ -279,6 +286,12 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 6200000, guid: be9f55ba61f4a45b2833211d464876b3, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
@@ -293,6 +306,25 @@ CompositeCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -305,11 +337,14 @@ CompositeCollider2D:
     m_Paths: []
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
+  m_UseDelaunayMesh: 0
+  m_CompositeGameObject: {fileID: 6496076142013766818}
 --- !u!1001 &6496076140753100257
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 6496076142013766817}
     m_Modifications:
     - target: {fileID: 710807718505192792, guid: ec7107b3aa4fe4e49b452f3d54ad1d6b, type: 3}
@@ -369,6 +404,9 @@ PrefabInstance:
       value: Box Collider
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ec7107b3aa4fe4e49b452f3d54ad1d6b, type: 3}
 --- !u!4 &6051704369510940857 stripped
 Transform:
@@ -380,6 +418,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 6496076142013766817}
     m_Modifications:
     - target: {fileID: 710807718505192792, guid: ec7107b3aa4fe4e49b452f3d54ad1d6b, type: 3}
@@ -439,6 +478,9 @@ PrefabInstance:
       value: Box Collider
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ec7107b3aa4fe4e49b452f3d54ad1d6b, type: 3}
 --- !u!4 &6051704370376709550 stripped
 Transform:

--- a/Assets/Prefabs/Ground Pieces/Nathan Part 2 Ground.prefab
+++ b/Assets/Prefabs/Ground Pieces/Nathan Part 2 Ground.prefab
@@ -103,8 +103,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: ce2049a96f4c844f1b01a3fb8ceee092, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -391,8 +391,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: dcbfd9c2cc6e14af697fb70728565a72, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -509,8 +509,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -673095393
-  m_SortingLayer: 1
+  m_SortingLayerID: -1052975445
+  m_SortingLayer: -4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b5711653132a84c64a2088a60d5ccabe, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Scenes/Levels/Chase.unity
+++ b/Assets/Scenes/Levels/Chase.unity
@@ -9424,6 +9424,8 @@ Transform:
   - {fileID: 375278794}
   - {fileID: 196500098}
   - {fileID: 2087787801}
+  - {fileID: 1894416616}
+  - {fileID: 2035837959}
   m_Father: {fileID: 1870436684}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1046477877
@@ -14382,6 +14384,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 616390217}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1514915634
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 132.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 52.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9922779
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.12403442
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -14.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592532, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
+      propertyPath: m_Name
+      value: Pit Enemy 1x
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bb2cc44181caebb4694246db4fd054b1, type: 3}
 --- !u!4 &1522706332 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3121044882252102163, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
@@ -15886,6 +15945,112 @@ Transform:
   - {fileID: 1361062910}
   m_Father: {fileID: 1870436684}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1894416615
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1046237322}
+    m_Modifications:
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1583734
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.254811
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 248.2453
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 53.8173
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9961947
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.08715578
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592532, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_Name
+      value: Long Pit Enemy (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779144, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_Name
+      value: Pit Enemy 3x (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 116.09
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 56.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9922779
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.12403442
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -14.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+--- !u!4 &1894416616 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+  m_PrefabInstance: {fileID: 1894416615}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1906080573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17309,6 +17474,112 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3121044882252102163, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
   m_PrefabInstance: {fileID: 2030961379}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2035837958
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1046237322}
+    m_Modifications:
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1583734
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.254811
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 248.2453
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 53.8173
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9961947
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.08715578
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592529, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014702933489592532, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_Name
+      value: Long Pit Enemy (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779144, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_Name
+      value: Pit Enemy 3x (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 126.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 54.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9922779
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.12403442
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -14.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+--- !u!4 &2035837959 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8649703735244779149, guid: eaf6307de982b6643aec4d4f276bd584, type: 3}
+  m_PrefabInstance: {fileID: 2035837958}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2051976634
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18051,11 +18322,11 @@ PrefabInstance:
       objectReference: {fileID: 6911116}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 265.1998
+      value: 265.19864
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 42.60041
+      value: 42.600426
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -18566,3 +18837,4 @@ SceneRoots:
   - {fileID: 1003855932}
   - {fileID: 5649544194877134407}
   - {fileID: 1222228126}
+  - {fileID: 1514915634}

--- a/Assets/Timelines/In-Game Cutscenes/Claire Part 1/C1 1 Claire Meets Stickman.playable
+++ b/Assets/Timelines/In-Game Cutscenes/Claire Part 1/C1 1 Claire Meets Stickman.playable
@@ -537,15 +537,6 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
-        value: -1.334667
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -560,15 +551,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
         value: 0
         inSlope: 0
         outSlope: 0

--- a/Assets/Timelines/In-Game Cutscenes/Claire Part 2/C2 1.1 Claire Chair.playable
+++ b/Assets/Timelines/In-Game Cutscenes/Claire Part 2/C2 1.1 Claire Chair.playable
@@ -240,7 +240,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
   m_Name: Signal Emitter(Clone)
   m_EditorClassIdentifier: 
-  m_Time: 1.5166666666666666
+  m_Time: 1.5
   m_Retroactive: 0
   m_EmitOnce: 0
   m_Asset: {fileID: 11400000, guid: 709e5494e37ef4bc2af30de6612ab0b4, type: 2}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -45,10 +45,10 @@ TagManager:
   - 
   - Hidden In-Game
   m_SortingLayers:
-  - name: Background Image
+  - name: Paper Background
     uniqueID: 3549980245
     locked: 0
-  - name: Background Pieces
+  - name: Background
     uniqueID: 3241991851
     locked: 0
   - name: Instructions


### PR DESCRIPTION
- fix issue where stickman appears behind the level texture in some levels
  - reason: the wrong sprite renderer order was set
- re-add missing scribbles in chase level
- fix some additional cutscene bugs