### PR TITLE
Wall speeds up when too far from player

### DIFF
--- a/Assets/Scenes/Levels/Chase.unity
+++ b/Assets/Scenes/Levels/Chase.unity
@@ -4700,7 +4700,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 704
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_SizeDelta.y
@@ -4708,7 +4708,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -4884,7 +4884,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8897684364883946034, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8897684364883946034, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9890,10 +9890,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1222228126}
     m_Modifications:
-    - target: {fileID: 251225031610431510, guid: 4a7e8d2d42c073348bcf2b0dddb9779c, type: 3}
-      propertyPath: achievement
-      value: 10
-      objectReference: {fileID: 0}
     - target: {fileID: 7222487035169883523, guid: 98702e3f3a4f9204f8f759dc6005eb3e, type: 3}
       propertyPath: onTrigger.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -9965,6 +9961,10 @@ PrefabInstance:
     - target: {fileID: 8946716281401585610, guid: 98702e3f3a4f9204f8f759dc6005eb3e, type: 3}
       propertyPath: m_Name
       value: Player Trigger - Fake Route Achievement
+      objectReference: {fileID: 0}
+    - target: {fileID: 251225031610431510, guid: 4a7e8d2d42c073348bcf2b0dddb9779c, type: 3}
+      propertyPath: achievement
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -15836,6 +15836,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1256590537236634895}
     - target: {fileID: 9183641255959064037, guid: dbba2b5fa6d5647bcbc7181a3e1515f0, type: 3}
+      propertyPath: speedUpDistance
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 9183641255959064037, guid: dbba2b5fa6d5647bcbc7181a3e1515f0, type: 3}
       propertyPath: points.Array.size
       value: 10
       objectReference: {fileID: 0}
@@ -18854,11 +18858,11 @@ PrefabInstance:
       objectReference: {fileID: 6911116}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 267.26
+      value: 268.06342
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 42.443085
+      value: 42.432022
       objectReference: {fileID: 0}
     - target: {fileID: 242199389748082403, guid: 81556ccb1927e3044ad98f2c790e52cb, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -12,7 +12,7 @@ public class Enemy : MonoBehaviour
 {
     // Configuration parameters
     [SerializeField] MovementType movementType = MovementType.Straight;
-    [SerializeField] private float speed;
+    [SerializeField] protected float speed;
 
     [Header("Straight Movement")]
     [SerializeField] protected List<Transform> points = new List<Transform>();

--- a/Assets/Scripts/Enemy/ScribbleWall.cs
+++ b/Assets/Scripts/Enemy/ScribbleWall.cs
@@ -7,8 +7,8 @@ using Random=UnityEngine.Random;
 public class ScribbleWall : Enemy
 {
     [SerializeField] private PlayerMovement playerMovement;
-    [SerializeField] private float speedUpDistance;
-    private float baseSpeed;
+    [SerializeField] private float speedUpDistance = 40;
+    [SerializeField] private float baseSpeed;
     private bool respawning = false;
     void FixedUpdate() {
         // If we're respawning, don't do anything.
@@ -42,15 +42,14 @@ public class ScribbleWall : Enemy
     }
     private void UpdateSpeed() {
         float distanceFromPlayer = Vector3.Distance(transform.position, playerMovement.transform.position);
-        Debug.Log("Distance: " + distanceFromPlayer);
+        Debug.Log("distance: " + distanceFromPlayer);
         if(distanceFromPlayer > speedUpDistance) {
             // Find how far away from "speedUpDistance" the wall is
             distanceFromPlayer -= speedUpDistance;
             // Divide by number to make smaller ;p
-            distanceFromPlayer /= 10;
             // Add exponential number to speed based on this number
-            distanceFromPlayer = distanceFromPlayer * distanceFromPlayer;
-            this.speed = baseSpeed + distanceFromPlayer;
+            distanceFromPlayer = distanceFromPlayer * 10;
+            this.speed = baseSpeed + 5 + distanceFromPlayer;
         } else {
             // If the wall gets within the threshhold, set speed back to the original speed.
             this.speed = baseSpeed;

--- a/Assets/Scripts/Enemy/ScribbleWall.cs
+++ b/Assets/Scripts/Enemy/ScribbleWall.cs
@@ -7,10 +7,12 @@ using Random=UnityEngine.Random;
 public class ScribbleWall : Enemy
 {
     [SerializeField] private PlayerMovement playerMovement;
-
+    [SerializeField] private float speedUpDistance;
+    private float baseSpeed;
     private bool respawning = false;
-    void Update() {
+    void FixedUpdate() {
         // If we're respawning, don't do anything.
+        UpdateSpeed();
         if(!respawning) {
             // If the player is dead & wall is not respawning, respawn this
             if(playerMovement.GetPlayerDead()) {
@@ -21,6 +23,9 @@ public class ScribbleWall : Enemy
                 MoveStraight();
             }
         }
+    }
+    void Awake() {
+        baseSpeed = speed;
     }
     // Vector3(-45,121.220001,0) OG Starting Position 
     public void StartRespawn() {
@@ -34,5 +39,21 @@ public class ScribbleWall : Enemy
     }
     public void setRespawnPosition(Vector3 pos) {
         originalPosition = pos;
+    }
+    private void UpdateSpeed() {
+        float distanceFromPlayer = Vector3.Distance(transform.position, playerMovement.transform.position);
+        Debug.Log("Distance: " + distanceFromPlayer);
+        if(distanceFromPlayer > speedUpDistance) {
+            // Find how far away from "speedUpDistance" the wall is
+            distanceFromPlayer -= speedUpDistance;
+            // Divide by number to make smaller ;p
+            distanceFromPlayer /= 10;
+            // Add exponential number to speed based on this number
+            distanceFromPlayer = distanceFromPlayer * distanceFromPlayer;
+            this.speed = baseSpeed + distanceFromPlayer;
+        } else {
+            // If the wall gets within the threshhold, set speed back to the original speed.
+            this.speed = baseSpeed;
+        }
     }
 }


### PR DESCRIPTION
- Changed access lvl of speed to scribblewall can access
- added Awake() in scribble wall b/c I didn't want to override the start() in enemy (idk if u can just add onto an existing function.. o well)
- Changed update() to fixedUpdate()
- Wall will now calc distance from player and increase speed based on distance (we can change it if too easy/too hard/ we think needs adjustment)