### PR TITLE
preload bgm/sfx audio files to fix lag spike

### DIFF
--- a/Assets/Audio/Ambience/CafeteriaAmbience.wav.meta
+++ b/Assets/Audio/Ambience/CafeteriaAmbience.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 628ddc1b083c204468283ad3a50bf364
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/ClassroomAmbience.wav.meta
+++ b/Assets/Audio/Ambience/ClassroomAmbience.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: b20dd0ff70c291a4db484e8ccec1d17c
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/House Ambience_mixdown.wav.meta
+++ b/Assets/Audio/Ambience/House Ambience_mixdown.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 9a863131e4037774092ec88353f6585b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/Park1 Ambience.wav.meta
+++ b/Assets/Audio/Ambience/Park1 Ambience.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 396175c22e90c90438889ddb5e18cfc7
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/Park2 Ambience.wav.meta
+++ b/Assets/Audio/Ambience/Park2 Ambience.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 7370956196abb4c48b0d96a827a546d8
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/Police Siren.wav.meta
+++ b/Assets/Audio/Ambience/Police Siren.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: e59001e1060c88b4abcc991bbed8c090
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Ambience/Rumbling_mixdown.wav.meta
+++ b/Assets/Audio/Ambience/Rumbling_mixdown.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 950edde41bdbdf54fb9acdd7a54dc591
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Music/Chase.wav.meta
+++ b/Assets/Audio/Music/Chase.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/Music/Claire.wav.meta
+++ b/Assets/Audio/Music/Claire.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 6bba17e2b9c4ca942a6fc4ae05310377
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Music/Draw Medley.wav.meta
+++ b/Assets/Audio/Music/Draw Medley.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/Music/Main Menu.wav.meta
+++ b/Assets/Audio/Music/Main Menu.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ba3a6ff76f01c284799f3288e88f3e84
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Music/Mike.wav.meta
+++ b/Assets/Audio/Music/Mike.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: d939a98b030174049ac201e5c2c428f3
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/Music/Nathan 1.wav.meta
+++ b/Assets/Audio/Music/Nathan 1.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/Music/Nathan 2.wav.meta
+++ b/Assets/Audio/Music/Nathan 2.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/Music/Nathan 3.wav.meta
+++ b/Assets/Audio/Music/Nathan 3.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/Music/Tutorial.wav.meta
+++ b/Assets/Audio/Music/Tutorial.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: f7b1c35eafcd5014ba9fdf8c9b445dcc
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/eraser.wav.meta
+++ b/Assets/Audio/SFX/eraser.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 7baeef20888634c6cbb9e88c223ddb2b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/footstepsfx_final.wav.meta
+++ b/Assets/Audio/SFX/footstepsfx_final.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 13e20c2d37f825244a0836f8720151cd
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/markercircle.wav.meta
+++ b/Assets/Audio/SFX/markercircle.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 1e648a873b171407ba4c2201e790921a
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/markermark.wav.meta
+++ b/Assets/Audio/SFX/markermark.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 870057bfcd91a48dbbba74bbf6ed2299
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/markernew.wav.meta
+++ b/Assets/Audio/SFX/markernew.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Audio/SFX/pageflip.wav.meta
+++ b/Assets/Audio/SFX/pageflip.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 39a8a4a73dcda7d459d37dc2537d36e1
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/paperwobble.wav.meta
+++ b/Assets/Audio/SFX/paperwobble.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 3ad3bfde20ed7c04092da4574c1e0141
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/penciljump.wav.meta
+++ b/Assets/Audio/SFX/penciljump.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 0dc41abdbb06c406c82f649e24110e76
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/pencilpickup.wav.meta
+++ b/Assets/Audio/SFX/pencilpickup.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: f464c44ead9fb4e0cae5a4cc4481c299
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/pencilsharpen.wav.meta
+++ b/Assets/Audio/SFX/pencilsharpen.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: d2954d8e7083d42e79b6c826ca300dcb
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/penclick.wav.meta
+++ b/Assets/Audio/SFX/penclick.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ef487a1095b5e4a7c9a5301d0525b99c
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Audio/SFX/pop.wav.meta
+++ b/Assets/Audio/SFX/pop.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 330dde176470e4599a6d7346cb2b1163
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Prefabs/Level End Trigger.prefab
+++ b/Assets/Prefabs/Level End Trigger.prefab
@@ -143,3 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfcf774505e7de84c94ce160f5e29701, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  triggerableLayers:
+    serializedVersion: 2
+    m_Bits: 256

--- a/Assets/Prefabs/Stickman.prefab
+++ b/Assets/Prefabs/Stickman.prefab
@@ -131,11 +131,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 4.25
-  maxWalkForce: 4
   jumpForce: 29.5
   deferredJumpDelay: 0.1
   coyoteJumpDelay: 0.1
-  quickFallGravityScale: 1.5
+  quickFallGravityScale: 1.25
   ground:
     serializedVersion: 2
     m_Bits: 33856

--- a/Assets/Presets/AudioImporter.preset
+++ b/Assets/Presets/AudioImporter.preset
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!181963792 &2655988077585873504
+Preset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AudioImporter
+  m_TargetType:
+    m_NativeTypeID: 1020
+    m_ManagedTypePPtr: {fileID: 0}
+    m_ManagedTypeFallback: 
+  m_Properties:
+  - target: {fileID: 0}
+    propertyPath: m_ExternalObjects.Array.size
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.loadType
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.sampleRateSetting
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.sampleRateOverride
+    value: 44100
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.compressionFormat
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.quality
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.conversionMode
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_DefaultSettings.preloadAudioData
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_PlatformSettingOverrides.Array.size
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_ForceToMono
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Normalize
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_LoadInBackground
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_Ambisonic
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_3D
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_UserData
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_AssetBundleName
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_AssetBundleVariant
+    value: 
+    objectReference: {fileID: 0}
+  m_ExcludedProperties: []

--- a/Assets/Presets/AudioImporter.preset.meta
+++ b/Assets/Presets/AudioImporter.preset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fed1f5a5dc69eb542b3fb8b7b35bf525
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2655988077585873504
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Dialogue/claire/multi/claire2_03.wav.meta
+++ b/Assets/Resources/Dialogue/claire/multi/claire2_03.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 5cbc6eebe89a9144f805f8fec159120b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/claire/multi/claire2_05.wav.meta
+++ b/Assets/Resources/Dialogue/claire/multi/claire2_05.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 661ac65cc74071c42b5355f6e291ac7b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/claire/multi/claire2_07.wav.meta
+++ b/Assets/Resources/Dialogue/claire/multi/claire2_07.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c9548a3aa39ba924c89cb4392bd76302
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/claire/single/claire_03.wav.meta
+++ b/Assets/Resources/Dialogue/claire/single/claire_03.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 46640ea8de3d84a41999fa5f1f2bc30f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/mike/multi/mike_01.wav.meta
+++ b/Assets/Resources/Dialogue/mike/multi/mike_01.wav.meta
@@ -11,7 +11,7 @@ AudioImporter:
     compressionFormat: 1
     quality: 1
     conversionMode: 0
-    preloadAudioData: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1

--- a/Assets/Resources/Dialogue/mike/multi/mike_02.wav.meta
+++ b/Assets/Resources/Dialogue/mike/multi/mike_02.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c98bd39223a65fb40b24cabbeedfbd24
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/mike/single/mike_09.wav.meta
+++ b/Assets/Resources/Dialogue/mike/single/mike_09.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ceaeafa1a27db9a4c81407e1f7709be6
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_01.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_01.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 7745437e0569cfc4b95a73561ee41b07
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_03.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_03.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 3680c25ddbc17184984a6c70fa40b4c3
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_04.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_04.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 1fbab5450357df9498ac753df7dc8de3
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_05.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_05.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 5a4455a7647a7064bb69f9e8a0e4922e
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_06.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_06.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: f313a1bf9c51a4c4ba8789a587327b56
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_09.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_09.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 8f160d46e7f2ba442844b8436d74adba
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/nathan/multi/nathan2_11.wav.meta
+++ b/Assets/Resources/Dialogue/nathan/multi/nathan2_11.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 129449a8dafbfe3469634d5d17c876aa
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Resources/Dialogue/teacher/single/teacher1.wav.meta
+++ b/Assets/Resources/Dialogue/teacher/single/teacher1.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 1097f486e37930d42bb6599b686c069f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Scripts/LevelEndTrigger.cs
+++ b/Assets/Scripts/LevelEndTrigger.cs
@@ -5,20 +5,28 @@ using UnityEngine.Events;
 
 public class LevelEndTrigger : MonoBehaviour
 {
-    private bool triggered;
-    void Start() {
-        triggered = false;
+    [SerializeField] private LayerMask triggerableLayers;
+    private bool hasTriggered;
+
+    void Start()
+    {
+        hasTriggered = false;
     }
-    private void OnTriggerEnter2D(Collider2D other) {
-        LoadNextScene();
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        bool layerIsTriggerable = triggerableLayers == (triggerableLayers | (1 << other.gameObject.layer));
+        if (!hasTriggered && layerIsTriggerable)
+        {
+            LoadNextScene();
+        }
     }
 
     [ContextMenu("Load Next Scene")]
-    public void LoadNextScene() {
-        if(!triggered) {
-            FindObjectOfType<SceneLoader>().LoadNextScene();
-            FindObjectOfType<PlayerMovement>()?.SetCanMove(0);
-            triggered = true;
-        }
+    public void LoadNextScene()
+    {
+        FindObjectOfType<SceneLoader>().LoadNextScene();
+        FindObjectOfType<PlayerMovement>()?.SetCanMove(0);
+        hasTriggered = true;
     }
 }


### PR DESCRIPTION
- update the audio files' meta files/import settings to preload the audio files
  - this prevents lag spikes from loading the audio file while in-game
  - the lag spikes were most prominent with the nathan BGM
- also, limit levelendtrigger activation to player only to prevent scribble wall from activating it