### PR TITLE
place reset button correctly if drawing area is rotated

### DIFF
--- a/Assets/Prefabs/Drawing Canvas/Drawing Canvas.prefab
+++ b/Assets/Prefabs/Drawing Canvas/Drawing Canvas.prefab
@@ -215,8 +215,8 @@ GameObject:
   m_Component:
   - component: {fileID: 633927549496715983}
   - component: {fileID: 3564175686117655857}
+  - component: {fileID: 4466684607862093935}
   - component: {fileID: 1421605840355200629}
-  - component: {fileID: 8835778989067241093}
   - component: {fileID: 2652519995096693943}
   - component: {fileID: 8854421708622221738}
   m_Layer: 14
@@ -235,7 +235,7 @@ Transform:
   m_GameObject: {fileID: 6013472230435510633}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.11433, y: 2.1976702, z: -1.01}
+  m_LocalPosition: {x: -2.8143332, y: 2.1976624, z: -1.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -254,8 +254,44 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offset: {x: 0.15, y: -0.1, z: -1}
+  placement: 1
   drawingCanvas: {fileID: 3121044882252102164}
   drawingArea: {fileID: 7562454472242513397}
+--- !u!58 &4466684607862093935
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6013472230435510633}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.33333334
 --- !u!212 &1421605840355200629
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -308,51 +344,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &8835778989067241093
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6013472230435510633}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.48, y: 0.48}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.66666, y: 0.66666}
-  m_EdgeRadius: 0
 --- !u!82 &2652519995096693943
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Chase.unity
+++ b/Assets/Scenes/Levels/Chase.unity
@@ -548,11 +548,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.6758423
+      value: 2.4058533
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206749
+      value: 1.765255
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -1093,7 +1093,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1452751
+      value: 1.1452675
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -2548,11 +2548,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.675827
+      value: 2.4058533
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206749
+      value: 1.765255
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -2764,7 +2764,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1452751
+      value: 1.1452675
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -5198,11 +5198,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.763527
+      value: 2.7635345
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.4960709
+      value: 1.4960632
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -5417,7 +5417,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 704
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_SizeDelta.y
@@ -5425,7 +5425,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 19695496635550507, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -5601,7 +5601,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8897684364883946034, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 8897684364883946034, guid: d60c72154615d6647886d637e1c4cc67, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -5739,11 +5739,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.7788004
+      value: 1.7788142
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.88217163
+      value: 0.8821678
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -10662,7 +10662,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.88217163
+      value: 0.8821678
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -11563,11 +11563,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.8154755
+      value: 5.8154907
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.61907196
+      value: 0.61906433
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -11872,6 +11872,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1222228126}
     m_Modifications:
+    - target: {fileID: 251225031610431510, guid: 4a7e8d2d42c073348bcf2b0dddb9779c, type: 3}
+      propertyPath: achievement
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7222487035169883523, guid: 98702e3f3a4f9204f8f759dc6005eb3e, type: 3}
       propertyPath: onTrigger.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -11944,10 +11948,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player Trigger - Fake Route Achievement
       objectReference: {fileID: 0}
-    - target: {fileID: 251225031610431510, guid: 4a7e8d2d42c073348bcf2b0dddb9779c, type: 3}
-      propertyPath: achievement
-      value: 10
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -11968,11 +11968,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.8865204
+      value: 1.8865356
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206692
+      value: 1.3206673
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -12225,11 +12225,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.8865204
+      value: -1.8865356
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206692
+      value: 1.3206673
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -12307,6 +12307,14 @@ PrefabInstance:
       propertyPath: maxTotalLineLength
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -12332,11 +12340,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.23601
+      value: 8.236013
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.69057465
+      value: 0.690567
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -14504,11 +14512,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.23732
+      value: 2.2373352
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206749
+      value: 1.3206673
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -15252,11 +15260,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.9913177
+      value: -3.7013702
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206749
+      value: 1.9936905
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -15330,6 +15338,14 @@ PrefabInstance:
       propertyPath: linePrefab
       value: 
       objectReference: {fileID: 5434204094653489069, guid: e4988e8dce3115e49910cb86eebee306, type: 3}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -15350,11 +15366,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.4127274
+      value: 2.412735
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1452713
+      value: 1.1452637
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -15527,11 +15543,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.8161469
+      value: -2.5440369
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206711
+      value: 1.7896194
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -15605,6 +15621,14 @@ PrefabInstance:
       propertyPath: linePrefab
       value: 
       objectReference: {fileID: 5434204094653489069, guid: e4988e8dce3115e49910cb86eebee306, type: 3}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -15863,11 +15887,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.513794
+      value: -1.5138092
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206692
+      value: 1.3206673
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -15944,6 +15968,14 @@ PrefabInstance:
     - target: {fileID: 3121044882252102164, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: maxTotalLineLength
       value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -16120,7 +16152,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3706684
+      value: 1.3706665
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -16257,11 +16289,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.0619507
+      value: -1.7983704
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0206757
+      value: 1.3617973
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -16333,6 +16365,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3121044882252102163, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -16810,11 +16850,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.23732
+      value: 1.9740143
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3206749
+      value: 1.6891136
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -17293,11 +17333,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.5523834
+      value: 5.5523987
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5978966
+      value: 0.59788895
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -18870,11 +18910,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.7111206
+      value: -1.7111359
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.9698677
+      value: 0.9698658
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -18951,6 +18991,14 @@ PrefabInstance:
     - target: {fileID: 3121044882252102164, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: maxTotalLineLength
       value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -19256,11 +19304,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.23732
+      value: -2.2373352
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5399246
+      value: 1.539917
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -19337,6 +19385,14 @@ PrefabInstance:
     - target: {fileID: 3121044882252102164, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: maxTotalLineLength
       value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -19424,7 +19480,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.0095301
+      value: 1.0095334
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
@@ -20111,7 +20167,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.640995
+      value: 1.6409874
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -20543,11 +20599,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.6585083
+      value: -1.6585083
       objectReference: {fileID: 0}
     - target: {fileID: 633927549496715983, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.7238731
+      value: 2.7238655
       objectReference: {fileID: 0}
     - target: {fileID: 2942901708110038587, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
       propertyPath: m_LocalScale.x
@@ -20621,6 +20677,14 @@ PrefabInstance:
       propertyPath: linePrefab
       value: 
       objectReference: {fileID: 5434204094653489069, guid: e4988e8dce3115e49910cb86eebee306, type: 3}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: offset.x
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3564175686117655857, guid: 71d17e4c639a6d147b726089326d0abe, type: 3}
+      propertyPath: placement
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []


### PR DESCRIPTION
- improve the logic for calculating the position of the reset button if the drawing area is rotated
  - transform the offsets from local to world space to account for rotation
- add additional customization on which corner to place the reset button
  - aids in the chase level "funnel" where reset button need to be accessed but are out of view