### PR TITLE
fix out-of-order cutscene end frame evaluation + input/nav fixes

### DIFF
--- a/Assets/Animations/Checkpoint/Checkpoint Activated.anim
+++ b/Assets/Animations/Checkpoint/Checkpoint Activated.anim
@@ -45,7 +45,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0.03, y: 0.15, z: 0}
+        value: {x: 0.03, y: 0.35, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -151,7 +151,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.15
+        value: 0.35
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Animations/Checkpoint/Checkpoint Deactivated.anim
+++ b/Assets/Animations/Checkpoint/Checkpoint Deactivated.anim
@@ -36,7 +36,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0.3, y: 0.15, z: 0}
+        value: {x: 0.03, y: 0.35, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -103,7 +103,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.3
+        value: 0.03
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -124,7 +124,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.15
+        value: 0.35
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Prefabs/Background Pieces/Jumping Instructions.prefab
+++ b/Assets/Prefabs/Background Pieces/Jumping Instructions.prefab
@@ -27,11 +27,11 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8840006286419666639}
   - {fileID: 6312469049339983382}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -50,8 +50,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 443ee41664bcf0848bd25e49122fec94, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  distanceToFadeIn: 7
   fadeDuration: 1.5
+  distanceToFadeIn: 7
+  targetTransform: {fileID: 0}
 --- !u!1 &8451302332694667403
 GameObject:
   m_ObjectHideFlags: 0
@@ -80,9 +81,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 37571385617035640}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -100,6 +101,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -216,22 +218,27 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 3441329216139871675}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 3441329216139871675}
+  m_maskType: 0
 --- !u!1001 &4203804356383855648
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 37571385617035640}
     m_Modifications:
     - target: {fileID: 347421652320333645, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541499056529154699, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
+      propertyPath: m_fontColor.a
+      value: 0.043137256
       objectReference: {fileID: 0}
     - target: {fileID: 1964566955624696128, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
       propertyPath: m_Color.a
@@ -240,6 +247,10 @@ PrefabInstance:
     - target: {fileID: 2395517678651053231, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
       propertyPath: m_Color.a
       value: 0.2509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2423994632673148559, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
+      propertyPath: m_fontColor.a
+      value: 0.043137256
       objectReference: {fileID: 0}
     - target: {fileID: 4195930177716039110, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
       propertyPath: m_Name
@@ -341,7 +352,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9184481557383044694, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
+      propertyPath: m_fontColor.a
+      value: 0.043137256
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9cea3681ab352194eb65218ffad5f748, type: 3}
 --- !u!224 &6312469049339983382 stripped
 RectTransform:

--- a/Assets/Prefabs/Background Pieces/WASD Keys.prefab
+++ b/Assets/Prefabs/Background Pieces/WASD Keys.prefab
@@ -28,13 +28,13 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 157142986785022837}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.025}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &7638038508125704308
@@ -48,6 +48,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -164,12 +165,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 7638038508125704308}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 7638038508125704308}
+  m_maskType: 0
 --- !u!1 &1086126917799973977
 GameObject:
   m_ObjectHideFlags: 0
@@ -198,13 +199,13 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5956394667185148698}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.025}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &2941331459470839088
@@ -218,6 +219,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -334,12 +336,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 2941331459470839088}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 2941331459470839088}
+  m_maskType: 0
 --- !u!1 &1986265590775398241
 GameObject:
   m_ObjectHideFlags: 0
@@ -364,13 +366,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1986265590775398241}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8112597457012541491}
   m_Father: {fileID: 7911853598591509046}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &374006092444481840
 SpriteRenderer:
@@ -383,6 +386,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -449,13 +453,13 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5956394667185148698}
   - {fileID: 7719489411753643409}
   - {fileID: 157142986785022837}
   - {fileID: 4544631933047262326}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -486,13 +490,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4451194210832962942}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.8000002, y: 0.75, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1149994405547591337}
   m_Father: {fileID: 7911853598591509046}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1964566955624696128
 SpriteRenderer:
@@ -505,6 +510,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -573,13 +579,13 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7719489411753643409}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.025}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &1534726511754272262
@@ -593,6 +599,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -709,12 +716,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1534726511754272262}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1534726511754272262}
+  m_maskType: 0
 --- !u!1 &6047389342623906507
 GameObject:
   m_ObjectHideFlags: 0
@@ -739,13 +746,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6047389342623906507}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.75, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6061456985119687490}
   m_Father: {fileID: 7911853598591509046}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &6343791198041108892
 SpriteRenderer:
@@ -758,6 +766,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -826,13 +835,13 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4544631933047262326}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.025}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &161681954102133360
@@ -846,6 +855,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -962,12 +972,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 161681954102133360}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 161681954102133360}
+  m_maskType: 0
 --- !u!1 &8675057857237271190
 GameObject:
   m_ObjectHideFlags: 0
@@ -992,13 +1002,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8675057857237271190}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.8000002, y: 0.75, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5794360306427051262}
   m_Father: {fileID: 7911853598591509046}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &2395517678651053231
 SpriteRenderer:
@@ -1011,6 +1022,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Prefabs/Checkpoint.prefab
+++ b/Assets/Prefabs/Checkpoint.prefab
@@ -111,7 +111,7 @@ Transform:
   m_GameObject: {fileID: 2714120404976494015}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: -0.034899585, w: 0.99939084}
-  m_LocalPosition: {x: 0.039, y: 0.4, z: 0}
+  m_LocalPosition: {x: 0.03, y: 0.35, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Prefabs/Gameplay Systems/Dialogue System.prefab
+++ b/Assets/Prefabs/Gameplay Systems/Dialogue System.prefab
@@ -233,7 +233,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogue: {fileID: 0}
-  advanceKey: 32
   dialogueCanvas: {fileID: 170163530068015359}
   textbox: {fileID: 1743173846837283768}
   skipButton: {fileID: 5240933668209151127}
@@ -677,7 +676,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -0.79999924}
+  m_AnchoredPosition: {x: 0, y: 3}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7321099705625704922

--- a/Assets/Prefabs/UI/Dialog.prefab
+++ b/Assets/Prefabs/UI/Dialog.prefab
@@ -408,6 +408,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1b0ad11d4ea5df4eb602488cbf2ab5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectionOnShow: {fileID: 8776625953425562411}
+  returnSelectionOnHide: 1
 --- !u!1 &8848944391136673065
 GameObject:
   m_ObjectHideFlags: 0
@@ -552,6 +554,18 @@ PrefabInstance:
     m_TransformParent: {fileID: 2670697074764464968}
     m_Modifications:
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 6240841354318618699}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 6240841354318618699}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
       objectReference: {fileID: 0}
@@ -680,9 +694,25 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &8776625953425562409 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 6394268604661530777}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776625953425562411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &8776625953425562410 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 6394268604661530777}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8776625953425562411 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161586, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 6394268604661530777}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8640784265746168827
@@ -693,6 +723,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2670697074764464968}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8776625953425562409}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 8776625953425562409}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -823,3 +865,14 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 8640784265746168827}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6240841354318618699 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 8640784265746168827}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/Level Selector.prefab
+++ b/Assets/Prefabs/UI/Level Selector.prefab
@@ -983,9 +983,9 @@ RectTransform:
   - {fileID: 3020421700439271920}
   m_Father: {fileID: 255317763941158518}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 500, y: -143.3}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 500, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8561128337257286578
@@ -1107,9 +1107,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 255317763941158518}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 500, y: -39.65}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 500, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &541609612653213296
@@ -1590,7 +1590,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4347c267d03fa4ad495baa45d90582b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  menuHolder: {fileID: 0}
 --- !u!225 &5590758851032613307
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -1615,6 +1614,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1b0ad11d4ea5df4eb602488cbf2ab5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectionOnShow: {fileID: 8895688047484126405}
+  returnSelectionOnHide: 1
 --- !u!1 &6485749174199209928
 GameObject:
   m_ObjectHideFlags: 0
@@ -1923,6 +1924,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5147420507164648718}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 3591843772478041582}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 1
@@ -1937,6 +1954,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 671560940634285552}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7550166488790684991 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 671560940634285552}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1000406403268047955
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2045,6 +2073,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8365235739539545566}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 5714837375185894334}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 6524426895381010140}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 2
@@ -2054,6 +2102,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+--- !u!114 &7814978075693974684 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 1000406403268047955}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7814978075693974687 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
@@ -2167,6 +2226,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8895688047484126407}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5714837375185894334}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 6477364149832010735}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 1
@@ -2181,6 +2256,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 1549520712175054097}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8365235739539545566 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 1549520712175054097}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1938127084717028360
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2289,6 +2375,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 8365235739539545566}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2299,6 +2393,22 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 1938127084717028360}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8895688047484126405 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638413, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 1938127084717028360}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8895688047484126407 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 1938127084717028360}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8895688047484126405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2313001204657146865
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2407,6 +2517,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 5714837375185894334}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 7550166488790684991}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: C
@@ -2421,6 +2543,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 2313001204657146865}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4724037561256131390 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 2313001204657146865}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3375842805274463089
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2529,6 +2662,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8365235739539545566}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 7814978075693974684}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 1
@@ -2543,6 +2692,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 3375842805274463089}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5714837375185894334 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 3375842805274463089}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4067437750212868896
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2651,6 +2811,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8895688047484126407}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5714837375185894334}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 8365235739539545566}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 2
@@ -2665,6 +2841,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 4067437750212868896}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6477364149832010735 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 4067437750212868896}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4259599051241383443
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2773,6 +2960,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8365235739539545566}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 7814978075693974684}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 3
@@ -2782,6 +2985,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+--- !u!114 &6524426895381010140 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 4259599051241383443}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &6524426895381010143 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
@@ -2895,6 +3109,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5147420507164648718}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 7550166488790684991}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnRight
+      value: 
+      objectReference: {fileID: 333552990253370640}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 2
@@ -2909,6 +3143,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
   m_PrefabInstance: {fileID: 5786707243896757537}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &3591843772478041582 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 5786707243896757537}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7293383712215383519
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3017,6 +3262,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Level Selector Button (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 4724037561256131390}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5147420507164648718}
+    - target: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 3591843772478041582}
     - target: {fileID: 8567434067464665831, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
       propertyPath: m_text
       value: 3
@@ -3026,6 +3287,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+--- !u!114 &333552990253370640 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7031888636268638415, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
+  m_PrefabInstance: {fileID: 7293383712215383519}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &333552990253370643 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7031888636268638412, guid: 23e7bcbcdd426ad468878a9d4c16af78, type: 3}
@@ -3039,6 +3311,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 255317763941158518}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 7550166488790684991}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -3165,3 +3445,14 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 7358486013715627710}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5147420507164648718 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 7358486013715627710}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/Main Menu.prefab
+++ b/Assets/Prefabs/UI/Main Menu.prefab
@@ -36,9 +36,9 @@ RectTransform:
   - {fileID: 5837863381429126560}
   m_Father: {fileID: 52073782557188898}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 320, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 320, y: -259.2}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4451995481138521620
@@ -346,6 +346,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3cbe8b2844e781549ac34dbcf94cfa9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playButton: {fileID: 8103548546112292329}
   loadButton: {fileID: 5837863380791906531}
   playConfirmation: {fileID: 439532743568094665}
   preEndBackground: {fileID: 8103548545121960144}
@@ -584,6 +585,14 @@ PrefabInstance:
     m_TransformParent: {fileID: 8103548545015917303}
     m_Modifications:
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 8103548546112292331}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
       objectReference: {fileID: 0}
@@ -761,6 +770,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 2378554145004266438}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &32516698094188662 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 2378554145004266438}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!82 &3392111825680316865 stripped
 AudioSource:
   m_CorrespondingSourceObject: {fileID: 1013699002414176775, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
@@ -774,6 +794,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4481149676524457612}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 32516698094188662}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5837863380791906529}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -900,6 +932,22 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 5837863382547897947}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8103548546112292329 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161586, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 5837863382547897947}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8103548546112292331 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 5837863382547897947}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8103548546112292329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6124733338552965754
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -942,7 +990,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMin.x
@@ -950,7 +998,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_SizeDelta.x
@@ -962,11 +1010,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 2670697074764464968, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -337.38
       objectReference: {fileID: 0}
     - target: {fileID: 4859253808711683626, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_text
@@ -1000,13 +1048,17 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6240841354318618699, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMin.x
@@ -1014,11 +1066,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 704
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_SizeDelta.y
@@ -1026,11 +1078,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 6786692557487579729, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -143.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 8776625953425562409, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 8776625953425562409, guid: 86e1acbe207d26f44b804661eeb7914a, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -1107,6 +1163,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4481149676524457612}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 5837863380791906529}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5837863381429126563}
     - target: {fileID: 2409944388738161585, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_Enabled
       value: 1
@@ -1200,6 +1268,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &8386038670714167833 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 6129652093733337513}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &8386038670714167834 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
@@ -1213,6 +1292,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4481149676524457612}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8386038670714167833}
     - target: {fileID: 2409944388738161586, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_Name
       value: Settings Button
@@ -1307,6 +1394,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 8103548544959847955}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5837863381429126563 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 8103548544959847955}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &8103548545328728913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1315,6 +1413,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4481149676524457612}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 8103548546112292331}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 8386038670714167833}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -1460,6 +1570,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &5837863380791906529 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 8103548545328728913}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5837863380791906531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &5837863380791906530 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}

--- a/Assets/Prefabs/UI/Pause Menu.prefab
+++ b/Assets/Prefabs/UI/Pause Menu.prefab
@@ -136,7 +136,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b54fec7131560974faee641854fe1814, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pauseMenuCanvas: {fileID: 3603614029432125955}
 --- !u!223 &8476104351227755113
 Canvas:
   m_ObjectHideFlags: 0
@@ -182,7 +181,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &6055355659799945154
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,6 +237,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1b0ad11d4ea5df4eb602488cbf2ab5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectionOnShow: {fileID: 346671048982847547}
+  returnSelectionOnHide: 1
 --- !u!1 &1079068396275065311
 GameObject:
   m_ObjectHideFlags: 0
@@ -325,6 +326,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Text
       objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 1575444565951414620}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -458,9 +467,25 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &346671048982847545 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 2719691335977663369}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346671048982847547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &346671048982847546 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 2719691335977663369}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &346671048982847547 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161586, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
   m_PrefabInstance: {fileID: 2719691335977663369}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3795634928192166636
@@ -475,6 +500,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: Text
       objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 346671048982847545}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 6370499511694598093}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 0
@@ -610,6 +647,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &1575444565951414620 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 3795634928192166636}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &1575444565951414623 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
@@ -627,6 +675,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Text
       objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 1575444565951414620}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -752,6 +808,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &6370499511694598093 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 8726102692691444861}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &6370499511694598094 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}

--- a/Assets/Prefabs/UI/Settings Menu.prefab
+++ b/Assets/Prefabs/UI/Settings Menu.prefab
@@ -188,7 +188,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   versionTMPObj: {fileID: 7114805058030554632}
-  menuHolder: {fileID: 0}
 --- !u!114 &6824818371909299004
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -244,6 +243,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1b0ad11d4ea5df4eb602488cbf2ab5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectionOnShow: {fileID: 1583594590368427892}
+  returnSelectionOnHide: 1
 --- !u!1 &2539945635340520511
 GameObject:
   m_ObjectHideFlags: 0
@@ -1740,6 +1741,18 @@ PrefabInstance:
       value: UI Slider
       objectReference: {fileID: 0}
     - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 6072662492167674849}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 2939117719746155636}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -1849,6 +1862,14 @@ PrefabInstance:
       value: UI Slider
       objectReference: {fileID: 0}
     - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 7913315109412721109}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -1886,12 +1907,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3374261749040813059, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
   m_PrefabInstance: {fileID: 3061993039543370646}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1583594590368427892 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4576902493515050210, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+  m_PrefabInstance: {fileID: 3061993039543370646}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6072662492167674849 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
   m_PrefabInstance: {fileID: 3061993039543370646}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1583594590368427892}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
@@ -2010,6 +2036,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 2939117719746155636}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 1975557876569040840}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -2066,6 +2104,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 9206603723919259861}
     m_Modifications:
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 1975557876569040840}
     - target: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -2195,6 +2241,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+--- !u!114 &8028098858937608828 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409944388738161584, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
+  m_PrefabInstance: {fileID: 5627351945734713804}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &8028098858937608831 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2409944388738161587, guid: 5b08626c319ed5d4cbc1719807035e16, type: 3}
@@ -2260,6 +2317,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: UI Slider
       objectReference: {fileID: 0}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 7913315109412721109}
+    - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 4814044210580590133}
     - target: {fileID: 9095032843424077943, guid: 72dba2a9fea64fe4ab2435c1d674244a, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -2405,6 +2474,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 2939117719746155636}
+    - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 8028098858937608828}
     - target: {fileID: 8825520084368442578, guid: f8dbf78cd294f2746a6caaa8da57a077, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 1

--- a/Assets/Scripts/CutsceneTrigger.cs
+++ b/Assets/Scripts/CutsceneTrigger.cs
@@ -16,8 +16,9 @@ public class CutsceneTrigger : MonoBehaviour
     private TimelineTrigger trigger;
 
     // State variables
-    public bool hasPlayed;
-    public bool hasTriggered;
+    public bool hasPlayed; // has this cutscene been marked as completed?
+    public bool hasReachedEnd; // has the last frame of this timeline been evaluated?
+    public bool hasTriggered; // has player triggered this collider this session?
 
     private void Start()
     {
@@ -36,7 +37,7 @@ public class CutsceneTrigger : MonoBehaviour
                 return;
             }
 
-            bool dependenciesMet = dependencies.All(dependency => dependency.hasPlayed);
+            bool dependenciesMet = AllDependenciesMet();
             if (!dependenciesMet)
             {
                 Debug.Log("[CutsceneTrigger] Tried to trigger cutscene but its dependencies have not been played", gameObject);
@@ -51,7 +52,11 @@ public class CutsceneTrigger : MonoBehaviour
     public void GoToEndState()
     {
         Debug.Log($"[CutsceneTrigger] Going to end state of a cutscene", gameObject);
-        trigger.GoToEndState(cutscene);
+        if (cutscene)
+        {
+            trigger.GoToEndState(cutscene);
+        }
+        hasReachedEnd = true;
         hasPlayed = true;
     }
 
@@ -72,7 +77,16 @@ public class CutsceneTrigger : MonoBehaviour
 
     public IEnumerator CutsceneCoroutine()
     {
-        yield return trigger.StartCutscene(cutscene);
+        if (cutscene)
+        {
+            yield return trigger.StartCutscene(cutscene);
+        }
+        hasReachedEnd = true;
         hasPlayed = true;
+    }
+
+    public bool AllDependenciesMet()
+    {
+        return dependencies.All(dependency => dependency.hasReachedEnd);
     }
 }

--- a/Assets/Scripts/Dialogue/DialogueSystem.cs
+++ b/Assets/Scripts/Dialogue/DialogueSystem.cs
@@ -8,7 +8,6 @@ public class DialogueSystem : MonoBehaviour
 {
     // Configuration parameters
     [SerializeField] Dialogue dialogue;
-    [SerializeField] KeyCode advanceKey = KeyCode.Space;
     [SerializeField] GameObject dialogueCanvas;
     [SerializeField] Textbox textbox;
     [SerializeField] GameObject skipButton;
@@ -45,10 +44,10 @@ public class DialogueSystem : MonoBehaviour
     private bool CheckIfShouldAdvance()
     {
         // If the game is paused, do not advance
-        if (Time.timeScale <= 0) return false; 
+        if (Time.timeScale <= 0) return false;
 
         bool skipConfirmationVisible = skipConfirmationDialog.GetComponent<CanvasGroup>().interactable;
-        bool keyDown = !skipConfirmationVisible && Input.GetKeyDown(advanceKey);
+        bool keyDown = !skipConfirmationVisible && Input.GetButtonDown("Submit"); // Space or Enter
         return advanceRequested || keyDown;
     }
 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -67,8 +67,8 @@ public class PlayerMovement : MonoBehaviour
 
     private void Update()
     {
+        if (Time.timeScale == 0) return;
         if (isDead) return;
-
         if (isPaused)
         {
             anim.SetBool("Walking", false);
@@ -133,9 +133,10 @@ public class PlayerMovement : MonoBehaviour
 
     private void GetInput()
     {
-        horizontal = Input.GetAxisRaw("Horizontal");
         if (Input.GetButtonDown("Jump")) // W, Up, or Space
             jumpRequested = true;
+
+        horizontal = Input.GetAxisRaw("Horizontal");
         if (horizontal == 0)
             footstepAudioSource.Stop();
     }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -134,7 +134,7 @@ public class PlayerMovement : MonoBehaviour
     private void GetInput()
     {
         horizontal = Input.GetAxisRaw("Horizontal");
-        if (Input.GetButtonDown("Jump") || Input.GetButtonDown("Submit"))
+        if (Input.GetButtonDown("Jump")) // W, Up, or Space
             jumpRequested = true;
         if (horizontal == 0)
             footstepAudioSource.Stop();

--- a/Assets/Scripts/Saving and Loading/Serializable Data Objects/CutsceneData.cs
+++ b/Assets/Scripts/Saving and Loading/Serializable Data Objects/CutsceneData.cs
@@ -72,11 +72,23 @@ public class CutsceneData : MonoBehaviour
 
         if (cutsceneData == null)
             Debug.LogWarning($"[CutsceneData] Cutscene data not found for cutscene {ID}", gameObject);
-        else if (cutsceneData.hasPlayed)
+        else
         {
-            cutsceneTrigger.hasPlayed = true;
-            cutsceneTrigger.GoToEndState();
+            Debug.Log($"[CutsceneData] Loading cutscene data for cutscene {ID}", gameObject);
+            if (cutsceneData.hasPlayed)
+            {
+                cutsceneTrigger.hasPlayed = true;
+                StartCoroutine(GoToEndStateWhenReady());
+            }
         }
+    }
+
+    // Wait until the cutscenes that this cutscene depends on have been played. 
+    // Then evalue the last frame of the cutscene (fast forward to end).
+    IEnumerator GoToEndStateWhenReady()
+    {
+        yield return new WaitUntil(() => cutsceneTrigger.AllDependenciesMet());
+        cutsceneTrigger.GoToEndState();
     }
 
     // Returns a serializable version of the player's data

--- a/Assets/Scripts/TimelineTrigger.cs
+++ b/Assets/Scripts/TimelineTrigger.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Playables;
+using UnityEngine.Timeline;
+using System.Linq;
 
 public class TimelineTrigger : MonoBehaviour
 {
@@ -24,9 +26,40 @@ public class TimelineTrigger : MonoBehaviour
         yield return new WaitUntil(() => timeline.state == PlayState.Paused);
     }
 
-    public void GoToEndState(PlayableAsset cutscene)
+    public void GoToEndState(PlayableAsset cutscene, bool ignorePlayer = true)
     {
         timeline.playableAsset = cutscene;
+
+        // When going to the end state of a cutscene, we may not want to affect the player. 
+        // Otherwise, the player/Stickman tracks may override the playerData's loaded position.
+        if (ignorePlayer)
+        {
+            GameObject player = GameObject.FindWithTag("Player");
+
+            // Retrieve the bindings from the track to the objects in the currently loaded scene.
+            IEnumerable<PlayableBinding> playerOutputs = cutscene.outputs;
+            List<PlayableBinding> playerOutputsList = playerOutputs.ToList();
+
+            // Iterate through each track of the timeline.
+            for (int i = 0; i < playerOutputsList.Count(); i++)
+            {
+                TrackAsset track = (playerOutputsList[i].sourceObject) as TrackAsset;
+                if (track != null)
+                {
+                    Object referenceObject = timeline.GetGenericBinding(track);
+
+                    // Does this track reference the player GameObject?
+                    // If so, unbind the player from the track.
+                    if (referenceObject == player || (referenceObject as Behaviour)?.gameObject == player)
+                    {
+                        timeline.ClearGenericBinding(track);
+                    }
+                }
+            }
+        }
+
+        // Go to the last frame of the cutscene and evaluate it.
+        // The scene will be in the state as if the cutscene has already finished.
         timeline.time = timeline.duration;
         timeline.Evaluate();
         timeline.Stop();

--- a/Assets/Scripts/UI/Components/CanvasGroupVisibility.cs
+++ b/Assets/Scripts/UI/Components/CanvasGroupVisibility.cs
@@ -2,12 +2,17 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 [RequireComponent(typeof(Canvas))]
 [RequireComponent(typeof(CanvasGroup))]
 public class CanvasGroupVisibility : MonoBehaviour
 {
+    [SerializeField] private GameObject selectionOnShow;
+    [SerializeField] private bool returnSelectionOnHide = true;
+
     private CanvasGroup canvasGroup;
+    private GameObject selectionBeforeOpen;
 
     private void Start()
     {
@@ -19,5 +24,19 @@ public class CanvasGroupVisibility : MonoBehaviour
         canvasGroup.alpha = visibility ? 1f : 0f;
         canvasGroup.blocksRaycasts = visibility;
         canvasGroup.interactable = visibility;
+
+        EventSystem currEventSys = EventSystem.current;
+        if (visibility)
+        {
+            selectionBeforeOpen = currEventSys.currentSelectedGameObject;
+            if (selectionOnShow != null)
+            {
+                currEventSys.SetSelectedGameObject(selectionOnShow);
+            }
+        }
+        else if (returnSelectionOnHide && selectionBeforeOpen != null)
+        {
+            currEventSys.SetSelectedGameObject(selectionBeforeOpen);
+        }
     }
 }

--- a/Assets/Scripts/UI/Components/CanvasGroupVisibility.cs
+++ b/Assets/Scripts/UI/Components/CanvasGroupVisibility.cs
@@ -21,11 +21,14 @@ public class CanvasGroupVisibility : MonoBehaviour
 
     public void SetVisibility(bool visibility)
     {
+        // Set canvas group properties
         canvasGroup.alpha = visibility ? 1f : 0f;
         canvasGroup.blocksRaycasts = visibility;
         canvasGroup.interactable = visibility;
 
         EventSystem currEventSys = EventSystem.current;
+        // If showing this UI, focus on selectionOnShow if specified.
+        // Also, remember the currently focused object for when this UI hides.
         if (visibility)
         {
             selectionBeforeOpen = currEventSys.currentSelectedGameObject;
@@ -34,6 +37,8 @@ public class CanvasGroupVisibility : MonoBehaviour
                 currEventSys.SetSelectedGameObject(selectionOnShow);
             }
         }
+        // Else, this UI is hiding.
+        // Focus on the object that was focused before this UI was shown.
         else if (returnSelectionOnHide && selectionBeforeOpen != null)
         {
             currEventSys.SetSelectedGameObject(selectionBeforeOpen);

--- a/Assets/Scripts/UI/Credits.cs
+++ b/Assets/Scripts/UI/Credits.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.Playables;
 
@@ -10,10 +9,6 @@ public class Credits : MonoBehaviour
   [Header("Speed multipliers")]
   [SerializeField] public float normalSpeedMultiplier = 1f;
   [SerializeField] public float speedUpMultiplier = 5f;
-
-  [Header("Inputs to activate speed-up")]
-  [SerializeField] public KeyCode[] speedUpKeys = { KeyCode.Space, KeyCode.Return };
-  [SerializeField] public int[] speedUpButtons = { 0, 1 };
 
   // Cached components
   private PlayableDirector timeline;
@@ -30,9 +25,7 @@ public class Credits : MonoBehaviour
   private void Update()
   {
     // Update isSpedUp
-    bool newIsSpedUp =
-      speedUpButtons.Any(button => Input.GetMouseButton(button)) ||
-      speedUpKeys.Any(keyCode => Input.GetKey(keyCode));
+    bool newIsSpedUp = Input.GetButton("Submit") || Input.GetButton("Advance");
 
     // If isSpedUp has changes, update the actual speed multiplier of the playable object
     if (newIsSpedUp != isSpedUp)
@@ -47,8 +40,8 @@ public class Credits : MonoBehaviour
   {
     if (timeline != null && timeline.playableGraph.IsValid())
     {
-        Playable playable = timeline.playableGraph.GetRootPlayable(0);
-        playable.SetSpeed(speed);
+      Playable playable = timeline.playableGraph.GetRootPlayable(0);
+      playable.SetSpeed(speed);
     }
   }
 }

--- a/Assets/Scripts/UI/Level Selector/LevelSelector.cs
+++ b/Assets/Scripts/UI/Level Selector/LevelSelector.cs
@@ -37,7 +37,8 @@ public class LevelSelector : MonoBehaviour
     {
         if (LevelReached(level))
         {
-            if (!Global.LevelToBuildIndexMap.TryGetValue(level, out int buildIndex)) {
+            if (!Global.LevelToBuildIndexMap.TryGetValue(level, out int buildIndex))
+            {
                 Debug.LogError($"[LevelSelector] Tried to load scene {level} from levels menu, but the build index couldn't be found");
             }
             sceneLoader.LoadScene(buildIndex);
@@ -50,7 +51,7 @@ public class LevelSelector : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetButtonDown("Cancel")) // Esc
         {
             levelSelectorCanvas.SetVisibility(false);
         }

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -2,10 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 public class MainMenu : MonoBehaviour
 {
     [Header("Game Objects")]
+    public GameObject playButton;
     public GameObject loadButton;
     public GameObject playConfirmation;
     public GameObject preEndBackground;
@@ -31,20 +33,24 @@ public class MainMenu : MonoBehaviour
         bool hasCompletedGame = storeManager.QueryLevelReached(Global.Level.THE_END);
         preEndBackground.SetActive(!hasCompletedGame);
         postEndBackground.SetActive(hasCompletedGame);
+
+        EventSystem.current.SetSelectedGameObject(playButton);
     }
 
     public void RequestPlay()
     {
         // If there is an existing game save, prompt for confirmation
-        if (canLoad) {
+        if (canLoad)
+        {
             playConfirmation.GetComponent<CanvasGroupVisibility>().SetVisibility(true);
         }
-        else {
+        else
+        {
             Play();
         }
     }
 
-    public void Play() 
+    public void Play()
     {
         levelLoader.StartGame();
     }

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -9,15 +9,16 @@ public class PauseMenu : MonoBehaviour
 
     // State variables
     bool paused = false;    // Whether the game is paused
-    
-    void Start() {
+
+    void Start()
+    {
         pauseMenuCanvas = GetComponent<CanvasGroupVisibility>();
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetButtonDown("Cancel")) // Esc
         {
             if (paused)
                 Resume();

--- a/Assets/Scripts/UI/Settings Menu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/Settings Menu/SettingsMenu.cs
@@ -28,7 +28,7 @@ public class SettingsMenu : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetButtonDown("Cancel")) // Esc
         {
             settingsMenuCanvas.SetVisibility(false);
         }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -38,45 +38,13 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Fire1
+    m_Name: Advance
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left ctrl
+    positiveButton: mouse 0
     altNegativeButton: 
-    altPositiveButton: mouse 0
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Fire2
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left alt
-    altNegativeButton: 
-    altPositiveButton: mouse 1
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Fire3
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left shift
-    altNegativeButton: 
-    altPositiveButton: mouse 2
+    altPositiveButton: joystick button 0
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -93,6 +61,22 @@ InputManager:
     positiveButton: w
     altNegativeButton: 
     altPositiveButton: up
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Jump
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: space
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -182,54 +166,6 @@ InputManager:
     axis: 1
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Fire1
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: joystick button 0
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Fire2
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: joystick button 1
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Fire3
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: joystick button 2
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
     m_Name: Jump
     descriptiveName: 
     descriptiveNegativeName: 
@@ -293,195 +229,4 @@ InputManager:
     type: 0
     axis: 0
     joyNum: 0
-  - serializedVersion: 3
-    m_Name: Enable Debug Button 1
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left ctrl
-    altNegativeButton: 
-    altPositiveButton: joystick button 8
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Enable Debug Button 2
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: backspace
-    altNegativeButton: 
-    altPositiveButton: joystick button 9
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Reset
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left alt
-    altNegativeButton: 
-    altPositiveButton: joystick button 1
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Next
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: page down
-    altNegativeButton: 
-    altPositiveButton: joystick button 5
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Previous
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: page up
-    altNegativeButton: 
-    altPositiveButton: joystick button 4
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Validate
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: return
-    altNegativeButton: 
-    altPositiveButton: joystick button 0
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Persistent
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: right shift
-    altNegativeButton: 
-    altPositiveButton: joystick button 2
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Multiplier
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left shift
-    altNegativeButton: 
-    altPositiveButton: joystick button 3
-    gravity: 0
-    dead: 0
-    sensitivity: 0
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Horizontal
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Vertical
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: down
-    positiveButton: up
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 0
-    axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Vertical
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: down
-    positiveButton: up
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 2
-    axis: 6
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Debug Horizontal
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 1000
-    dead: 0.001
-    sensitivity: 1000
-    snap: 0
-    invert: 0
-    type: 2
-    axis: 5
-    joyNum: 0
+  m_UsePhysicalKeys: 1

--- a/ProjectSettings/PresetManager.asset
+++ b/ProjectSettings/PresetManager.asset
@@ -6,6 +6,22 @@ PresetManager:
   serializedVersion: 2
   m_DefaultPresets:
   - first:
+      m_NativeTypeID: 1020
+      m_ManagedTypePPtr: {fileID: 0}
+      m_ManagedTypeFallback: 
+    second:
+    - m_Preset: {fileID: 2655988077585873504, guid: fed1f5a5dc69eb542b3fb8b7b35bf525, type: 2}
+      m_Filter: 
+      m_Disabled: 0
+  - first:
+      m_NativeTypeID: 114
+      m_ManagedTypePPtr: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+      m_ManagedTypeFallback: 
+    second:
+    - m_Preset: {fileID: 2655988077585873504, guid: 754e51dce35362c4f83b53c45000b6db, type: 2}
+      m_Filter: 
+      m_Disabled: 0
+  - first:
       m_NativeTypeID: 1006
       m_ManagedTypePPtr: {fileID: 0}
       m_ManagedTypeFallback: 


### PR DESCRIPTION
* Animations/Checkpoint
  * updated the position keyframes
* Prefabs/Background Pieces
  * align the key text in the image
* Prefabs/DialogueSystem
  * align the key text in the CTC image
* Prefabs/UI
  * add support for focus and keyboard/controller navigation
* CutsceneTrigger.cs
  * make AllDependenciesMet() public so it can be accessed by CutsceneData
  * added variable hasReachedEnd to track whether the PlayableDirector has evaluated the cutscene's last frame
    * will be used by other CutsceneTriggers that depend on it
* CutsceneData.cs
  * add logic to unbind the player when evaluating the last frames of cutscenes
    * this is because evaluating the player's timeline/cutscene position will override the PlayerData position, causing a bug
* CanvasGroupVisiblity.cs
  *  add focus logic for when the canvas group visibility status changes
* Credits.cs, LevelSelector.cs, MainMenu.cs, PauseMenu.cs, SettingsMenu.cs
  * improve logic for detecting whether button is pressed
* PlayerMovement.cs
  * prevent requesting a jump when game is paused
* Updated InputManager.asset and PresetManager.asset