### PR TITLE
fix death animation playing twice in chase level

### DIFF
--- a/Assets/Scenes/Levels/Chase.unity
+++ b/Assets/Scenes/Levels/Chase.unity
@@ -32296,6 +32296,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9183641255959064039, guid: dbba2b5fa6d5647bcbc7181a3e1515f0, type: 3}
   m_PrefabInstance: {fileID: 1852309913}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1852309915 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9183641255959064037, guid: dbba2b5fa6d5647bcbc7181a3e1515f0, type: 3}
+  m_PrefabInstance: {fileID: 1852309913}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c27091dbcd24dd84988b82ab6287e79f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1861341641
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37521,6 +37532,34 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1222228126}
     m_Modifications:
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1852309915}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Respawn
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ScribbleWall, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1450883229827684608, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
+      propertyPath: onRespawn.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 1450883229827684621, guid: 5560dc89a02bbbd47b9a7cb886fe0d5f, type: 3}
       propertyPath: m_Name
       value: Stickman

--- a/Assets/Scripts/Enemy/ScribbleWall.cs
+++ b/Assets/Scripts/Enemy/ScribbleWall.cs
@@ -10,7 +10,6 @@ public class ScribbleWall : Enemy
     [SerializeField] private PlayerMovement playerMovement;
     [SerializeField] private float speedUpDistance = 40;
     [SerializeField] private float baseSpeed;
-    private bool respawning = false;
     void Update()
     {
         // Iterate through the points and connect them with a line in the editor.
@@ -28,37 +27,17 @@ public class ScribbleWall : Enemy
     }
     void FixedUpdate()
     {
-        // If we're respawning, don't do anything.
         UpdateSpeed();
-        if (!respawning)
-        {
-            // If the player is dead & wall is not respawning, respawn this
-            if (playerMovement.GetPlayerDead())
-            {
-                respawning = true;
-                StartRespawn();
-            }
-            else
-            {
-                // Otherwise, move forward
-                MoveStraight();
-            }
-        }
+        MoveStraight();
     }
     void Awake()
     {
         baseSpeed = speed;
     }
     // Vector3(-45,121.220001,0) OG Starting Position 
-    public void StartRespawn()
+    public void Respawn()
     {
-        StartCoroutine(Respawn(.99f));
-    }
-    IEnumerator Respawn(float wait)
-    {
-        yield return new WaitForSeconds(wait);
         transform.position = originalPosition;
-        respawning = false;
     }
     public void setRespawnPosition(Vector3 pos)
     {

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class PlayerMovement : MonoBehaviour
 {
@@ -17,11 +18,11 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private LayerMask ground;
     [SerializeField] private Collider2D feetCollider;
 
-    [Header("Auto Respawn")]
-    [SerializeField] private float minY = -20f;
+    [Header("Respawn")]
+    [SerializeField] private float minY = -20f; // Respawn once past this level
+    [SerializeField] private UnityEvent onRespawn;
 
     [Header("Audio Sources")]
-    // Audio sources
     [SerializeField] private AudioSource jumpAudioSource;
     [SerializeField] private AudioSource footstepAudioSource;
     [SerializeField] private AudioSource deathAudioSource;
@@ -241,10 +242,12 @@ public class PlayerMovement : MonoBehaviour
         rb2d.velocity = Vector2.zero;
 
         respawner?.StartObjectRespawn();
+        onRespawn.Invoke();
 
         // Move the player to the respawn position
         spawnAudioSource.Play();
         transform.position = respawnPos;
+
 
         // Unlock achievement if respawned a given number of times at the same point
         numRespawnsAtRespawnPoint += 1;


### PR DESCRIPTION
- fix death animation sometimes playing twice in chase level
  - happens when the scribble wall is at the player's respawn point for a narrow timeframe before it teleports
  - caused by timing discrepancy between Update loop (player movement) and FixedUpdate (scribble wall)
- instead of having the scribble wall checking if player is respawning, use a unity event emitted by playermovement instead.