### PR TITLE
Scribble Wall Respawn Logic More!!!

### DIFF
--- a/Assets/Scenes/Levels/Chase.unity
+++ b/Assets/Scenes/Levels/Chase.unity
@@ -2547,6 +2547,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 243.94366, y: 61.7, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!4 &156727164 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1618234120724272604, guid: c0fd5c6ca22e64d47b5622faab9795cc, type: 3}
@@ -3283,6 +3284,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 144.5, y: 66.11892, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!4 &184899945 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1618234120724272604, guid: c0fd5c6ca22e64d47b5622faab9795cc, type: 3}
@@ -3591,6 +3593,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 152.27202, y: 24.1, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!1 &226014314
 GameObject:
   m_ObjectHideFlags: 0
@@ -10725,6 +10728,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 188.7, y: 65.27113, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!1001 &614469193
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13551,6 +13555,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 93.6, y: 138.5, z: 0}
+  respawnTarget: {fileID: 1133499897}
 --- !u!4 &769947321 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1618234120724272604, guid: c0fd5c6ca22e64d47b5622faab9795cc, type: 3}
@@ -14611,6 +14616,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 152.3, y: 9.9, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!1001 &829193276
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15990,6 +15996,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 153.8, y: 36.137875, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!114 &891484257 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 156424493162379790, guid: c0fd5c6ca22e64d47b5622faab9795cc, type: 3}
@@ -17472,6 +17479,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: -24.55, y: 121.22, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!1 &1010015936
 GameObject:
   m_ObjectHideFlags: 0
@@ -17739,6 +17747,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 17.4, y: 121.22, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!114 &1028662914 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 156424493162379790, guid: c0fd5c6ca22e64d47b5622faab9795cc, type: 3}
@@ -35387,6 +35396,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   respawnOffset: {x: 0.5, y: 1.25, z: 0}
   wallRespawnPos: {x: 72.1, y: 66.557434, z: 0}
+  respawnTarget: {fileID: 0}
 --- !u!1 &1992334251
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/ScribbleWall.cs
+++ b/Assets/Scripts/Enemy/ScribbleWall.cs
@@ -10,6 +10,7 @@ public class ScribbleWall : Enemy
     [SerializeField] private PlayerMovement playerMovement;
     [SerializeField] private float speedUpDistance = 40;
     [SerializeField] private float baseSpeed;
+    private Transform respawnTarget;
     void Update()
     {
         // Iterate through the points and connect them with a line in the editor.
@@ -38,6 +39,7 @@ public class ScribbleWall : Enemy
     public void Respawn()
     {
         transform.position = originalPosition;
+        if(respawnTarget) index = points.IndexOf(respawnTarget);
     }
     public void setRespawnPosition(Vector3 pos)
     {
@@ -60,5 +62,8 @@ public class ScribbleWall : Enemy
             // If the wall gets within the threshhold, set speed back to the original speed.
             this.speed = baseSpeed;
         }
+    }
+    public void setRespawnTarget(Transform target) {
+        respawnTarget = target;
     }
 }

--- a/Assets/Scripts/Enemy/ScribbleWallCheckpoint.cs
+++ b/Assets/Scripts/Enemy/ScribbleWallCheckpoint.cs
@@ -5,6 +5,7 @@ public class ScribbleWallCheckpoint : Checkpoint
 {
     private ScribbleWall wall;
     [SerializeField] Vector3 wallRespawnPos;
+    [SerializeField] Transform respawnTarget;
 
     private void Start() 
     {
@@ -18,6 +19,7 @@ public class ScribbleWallCheckpoint : Checkpoint
         if (!isActivated && other.CompareTag("Player")) 
         {
             wall.setRespawnPosition(wallRespawnPos);
+            wall.setRespawnTarget(respawnTarget);
 
             PlayerMovement playerMovement = other.GetComponent<PlayerMovement>();
             if (playerMovement)


### PR DESCRIPTION
Scribble Wall checkpoint can now hold a reference to a pathpoint, and set a variable in scribble wall to it. (null if empty). if the path point is not null, set the scribble wall's current index path point to that point. (bugfix for a certain checkpoint)